### PR TITLE
only send query param for cloud_cover in mosaic create if enabled, only send first asset of assets to mosaic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## v0.4.0 - TBD
 
+### Changed
+
+- Env variable REACT_APP_TILER_PARAMS key `asset_bidx` changed to `bidx`. The format is
+  now just a comma-separated list of indexes (e.g., `1,2,3`) rather than of the form `asset-name|1,2,3`
+
 ### Added
 
 - Add mosaic view mode if REACT_APP_MOSAIC_TILER_URL (new) is defined
 - Env variable REACT_APP_MOSAIC_MAX_ITEMS
 
-### Changed
+## Fixed
 
-- Env variable REACT_APP_TILER_PARAMS key `asset_bidx` changed to `bidx`. The format is
-  now just a comma-separated list of indexes (e.g., `1,2,3`) rather than of the form `asset-name|1,2,3`
+- Single-file, multi-band mosaic compositing (e.g., NAIP) now works
 
 ## v0.3.0 - 2023-03-06
 

--- a/src/components/Search/envVarSetup.js
+++ b/src/components/Search/envVarSetup.js
@@ -52,10 +52,7 @@ const getTilerParams = () => {
   return {}
 }
 
-export const constructAssetsParam = (selectedCollection, tilerParams) => {
-  if (!tilerParams) {
-    tilerParams = getTilerParams()
-  }
+const constructAssetsParam = (selectedCollection, tilerParams) => {
   const assets = tilerParams[selectedCollection]?.assets || []
   if (!assets) {
     console.log(`Assets not defined for ${selectedCollection}`)
@@ -65,4 +62,14 @@ export const constructAssetsParam = (selectedCollection, tilerParams) => {
   // one asset specified
   const assetsStr = assets.join('&assets=')
   return assetsStr
+}
+
+export const constructMosaicAssetParam = (selectedCollection) => {
+  const assets = getTilerParams()[selectedCollection]?.assets || []
+  if (!assets) {
+    console.log(`Assets not defined for ${selectedCollection}`)
+    return null
+  } else {
+    return assets[0]
+  }
 }


### PR DESCRIPTION
**Related Issue(s):**

- n/a

**Proposed Changes:**

1. NAIP mosaic creating was failing because the query parameter with the cloud_cover constraint was always being sent, which always returns 0 results. This fixes is it by conditionally sending that constraint.
2. Landsat (a multi-file composite) was failing because a string for multiple assets was being sent, instead of only the first one. This still doesn't work because of the color_formula is defined for 3 bands instead of only one, but that will be fixed in an upcoming PR.

**PR Checklist:**

- [X] I have added my changes to the [CHANGELOG](https://github.com/Element84/filmdrop-ui/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
