### PR TITLE
Adjust zoom notice styling to not cover geosearch

### DIFF
--- a/src/components/Layout/Content/BottomContent/BottomContent.css
+++ b/src/components/Layout/Content/BottomContent/BottomContent.css
@@ -9,7 +9,8 @@
 .ZoomNotice {
   position: absolute;
   top: 11px;
-  left: 50px;
+  left: 50%;
+  transform: translateX(-50%);
   z-index: 1;
   background: #353d4f;
   padding: 10px 30px;


### PR DESCRIPTION
**Related Issue(s):**

- N/A

**Proposed Changes:**

1. Move zoom level notice over to the center so it doesn't cover geosearch

**PR Checklist:**

- [X]  CHANGELOG entry is not required.
