### PR TITLE
fix bug with sar:polarization param

### DIFF
--- a/src/components/Search/Search.js
+++ b/src/components/Search/Search.js
@@ -215,7 +215,9 @@ const Search = () => {
 
   useEffect(() => {
     if (_sarPolarizations) {
-      sarPolarizationsRef.current = _sarPolarizations
+      sarPolarizationsRef.current = true
+    } else {
+      sarPolarizationsRef.current = false
     }
   }, [_sarPolarizations])
 


### PR DESCRIPTION
**Related Issue(s):**

- NA

**Proposed Changes:**

1. change sarPolarizationsRef to be set as bool directly instead of being set equal to redux state value

**PR Checklist:**

- [ X] I have added my changes to the [CHANGELOG](https://github.com/Element84/filmdrop-ui/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
