### PR TITLE
release prep for v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## v2.0.0 - 2023-05-04
+## v2.0.0 - TBD
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased - TBD
+## v2.0.0 - 2023-05-04
 
-## Fixed
+### Fixed
 
 - Datetime search now searches from midnight UTC on the start date to immediately before midnight
   on the day after the end date (i.e., the last instant on the end date)
-
-## v1.1.0 - TBD
 
 ### Changed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "filmdrop-ui",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "filmdrop-ui",
-      "version": "1.0.1",
+      "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.10.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "filmdrop-ui",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "license": "Apache-2.0",
   "dependencies": {
     "@emotion/react": "^11.10.8",


### PR DESCRIPTION
**Related Issue(s):**

- n/a

**Proposed Changes:**

1. release prep for 2.0.0. Not going to actually release this version yet, but with the CRA->Vite migration and the new build work, we're definitely going to be 2.x and the 1.1.0 was release from another branch already.

**PR Checklist:**

- [X] I have added my changes to the [CHANGELOG](https://github.com/Element84/filmdrop-ui/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
