### PR TITLE
update import for colormap

### DIFF
--- a/src/utils/colorMap.js
+++ b/src/utils/colorMap.js
@@ -1,5 +1,5 @@
 import { COLORMAP } from '../components/defaults'
-import * as colormap from 'colormap'
+import colormap from 'colormap'
 
 export const colorMap = (largestRatio) => {
   return colormap({


### PR DESCRIPTION
**Related Issue(s):**

- NA

**Proposed Changes:**

1. changes import to only be `colormap` directly as default import

**To Test:**

- run `npm run build` then `npm run serve`
- open browser dev tools
- select COP DEM
- zoom out to hex level
- confirm hex grid shows as expected
- confirm not erros in console

**PR Checklist:**

- [X ] I have added my changes to the [CHANGELOG](https://github.com/Element84/filmdrop-ui/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
