### PR TITLE
support high DPI screens with 2x scale factor for scene tiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Datetime search now searches from midnight UTC on the start date to immediately before midnight
   on the day after the end date (i.e., the last instant on the end date)
 
+## Added
+
+- For high DPI screens (e.g., Retina), scene image tiling is now done at scale of 2 (previously, scale of 1).
+
 ## v1.1.0 - TBD
 
 ### Changed

--- a/src/components/Search/Search.jsx
+++ b/src/components/Search/Search.jsx
@@ -595,6 +595,12 @@ const Search = () => {
     })
   }
 
+  const scale = () =>
+    (window.devicePixelRatio && window.devicePixelRatio >= 2) ||
+    (window.matchMedia && window.matchMedia('(min-resolution: 192dpi)').matches)
+      ? 2
+      : 1
+
   // remove old image layer and add new Tiler image layer to map
   function addImageClicked(feature) {
     // show loading spinner
@@ -614,7 +620,7 @@ const Search = () => {
         const tileBounds = setupBounds(json.bbox)
         if (sceneTilerURL) {
           L.tileLayer(
-            `${sceneTilerURL}/stac/tiles/{z}/{x}/{y}.png?url=${featureURL}&${tilerParams}`,
+            `${sceneTilerURL}/stac/tiles/{z}/{x}/{y}@${scale()}x.png?url=${featureURL}&${tilerParams}`,
             {
               tileSize: 256,
               bounds: tileBounds,


### PR DESCRIPTION
**Related Issue(s):**

- https://github.com/Element84/filmdrop-ui/issues/36

**Proposed Changes:**

1. use 2x scale factor for high dpi displays (e.g., Retina)

**PR Checklist:**

- [X] I have added my changes to the [CHANGELOG](https://github.com/Element84/filmdrop-ui/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
