### PR TITLE
fix bug clearing search response from state

### DIFF
--- a/src/components/Search/Search.jsx
+++ b/src/components/Search/Search.jsx
@@ -479,12 +479,12 @@ const Search = () => {
       try {
         const { response, options } = await getResults(typeOfSearch)
         if (response) {
+          clearResultsFromMap()
           dispatch(setSearchResults(response))
           searchResultsRef.current = response
           dispatch(setSearchLoading(false))
 
           // add new footprints to map
-          clearResultsFromMap()
           const resultFootprintsFound = L.geoJSON(response, options)
           resultFootprintsFound.id = 'resultLayer'
           resultFootprintsFound.addTo(resultFootprintsRef.current)


### PR DESCRIPTION
**Related Issue(s):**

- NA

**Proposed Changes:**

1. Move `clearResultsFromMap` function to be called prior to new response being set in redux state

**PR Checklist:**

- [X] I have added my changes to the [CHANGELOG](https://github.com/Element84/filmdrop-ui/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
