### PR TITLE
update example config with color formula for l2a

### DIFF
--- a/src/assets/config.example.js
+++ b/src/assets/config.example.js
@@ -10,7 +10,10 @@ export const VITE_DASHBOARD_BTN_URL = 'https://dashboard.example.com'
 export const VITE_ANALYZE_BTN_URL = 'https://dashboard.example.com'
 export const VITE_CF_TEMPLATE_URL = 'https://cf-template.example.com'
 export const VITE_SCENE_TILER_PARAMS = {
-  'sentinel-2-l2a': { assets: ['visual'] },
+  'sentinel-2-l2a': {
+    assets: ['red', 'green', 'blue'],
+    color_formula: 'Gamma+RGB+3.2+Saturation+0.8+Sigmoidal+RGB+12+0.35'
+  },
   'landsat-c2-l2': {
     assets: ['red', 'green', 'blue'],
     color_formula: 'Gamma+RGB+1.7+Saturation+1.7+Sigmoidal+RGB+15+0.35'


### PR DESCRIPTION
**Related Issue(s):**

- NA

**Proposed Changes:**

1. update example config for sentinel-2-l2a to use composited image from titiler with color formula applied instead of visual asset

**PR Checklist:**

- [X] I have added my changes to the [CHANGELOG](https://github.com/Element84/filmdrop-ui/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
