### PR TITLE
Ba/bug/default to show fd logo

### DIFF
--- a/src/components/Layout/PageHeader/PageHeader.jsx
+++ b/src/components/Layout/PageHeader/PageHeader.jsx
@@ -38,7 +38,7 @@ const PageHeader = () => {
             </span>
           </Box>
         )}
-        {_appConfig.SHOW_BRAND_LOGO && (
+        {!('SHOW_BRAND_LOGO' in _appConfig) || _appConfig.SHOW_BRAND_LOGO ? (
           <a
             href="https://element84.com/filmdrop"
             title="Learn more about FilmDrop"
@@ -49,7 +49,7 @@ const PageHeader = () => {
               className="headerLogoImage filmDrop"
             />
           </a>
-        )}
+        ) : null}
       </div>
     </div>
   )

--- a/src/components/Layout/PageHeader/PageHeader.test.jsx
+++ b/src/components/Layout/PageHeader/PageHeader.test.jsx
@@ -26,7 +26,7 @@ describe('PageHeader', () => {
         })
       ).toBeInTheDocument()
     })
-    it('should load the filmdrop logo into the document if SHOW_BRAND_LOGO set to true in config', () => {
+    it('should load the filmdrop logo into the document if SHOW_BRAND_LOGO does not exists in config', () => {
       const SHOW_BRAND_LOGO = mockAppConfig.SHOW_BRAND_LOGO
       const mockAppConfigSearchEnabled = {
         SHOW_BRAND_LOGO,

--- a/src/components/Layout/PageHeader/PageHeader.test.jsx
+++ b/src/components/Layout/PageHeader/PageHeader.test.jsx
@@ -26,6 +26,20 @@ describe('PageHeader', () => {
         })
       ).toBeInTheDocument()
     })
+    it('should load the filmdrop logo into the document if SHOW_BRAND_LOGO set to true in config', () => {
+      const SHOW_BRAND_LOGO = mockAppConfig.SHOW_BRAND_LOGO
+      const mockAppConfigSearchEnabled = {
+        SHOW_BRAND_LOGO,
+        ...mockAppConfig
+      }
+      store.dispatch(setappConfig(mockAppConfigSearchEnabled))
+      setup()
+      expect(
+        screen.queryByRole('img', {
+          name: /filmdrop by element 84/i
+        })
+      ).toBeInTheDocument()
+    })
     it('should not load the filmdrop logo into the document if SHOW_BRAND_LOGO set to false in config', () => {
       const mockAppConfigSearchEnabled = {
         ...mockAppConfig,


### PR DESCRIPTION
**Related Issue(s):**

- NA

**Proposed Changes:**

1. Sets default for logo in top right of UI to show unless explicitly set to false in config 

### To test:

- remove `SHOW_BRAND_LOGO` value from local config
- run app
- confirm FD/E84 brand logo shows
- stop app
- add `SHOW_BRAND_LOGO` value to local config and set to true
- run app
- confirm FD/E84 brand logo still shows
- stop app
- change `SHOW_BRAND_LOGO` value to local config to false
- run app
- confirm FD/E84 brand logo does not show

tests pass 🍏 

**PR Checklist:**

- [X] I have added my changes to the [CHANGELOG](https://github.com/Element84/filmdrop-ui/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
