### PR TITLE
Ba/feature/add cart button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 3.2.0
+## Unreleased
+
+### Added
+
+- Cart button added to search bar if config set to true (WIP feature)
+
+## 3.2.0 - 2023-08-02
 
 ### Changed
 
@@ -15,7 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Added Legend
 
-## 3.1.0
+## 3.1.0 - 2023-07-27
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Cart button added to search bar if config set to true (WIP feature)
+- Cart button added to search bar if `CART_ENABLED` set to true in `config.json` (WIP feature)
 
 ## 3.2.0 - 2023-08-02
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import SystemMessage from './components/SystemMessage/SystemMessage'
 import { GetCollectionsService } from './services/get-collections-service'
 import { LoadConfigIntoStateService } from './services/get-config-service'
 import { useSelector } from 'react-redux'
+import CartModal from './components/Cart/CartModal/CartModal'
 
 function App() {
   const _showPublishModal = useSelector(
@@ -21,6 +22,7 @@ function App() {
     (state) => state.mainSlice.showApplicationAlert
   )
   const _appConfig = useSelector((state) => state.mainSlice.appConfig)
+  const _showCartModal = useSelector((state) => state.mainSlice.showCartModal)
 
   useEffect(() => {
     LoadConfigIntoStateService()
@@ -43,6 +45,7 @@ function App() {
             <UploadGeojsonModal></UploadGeojsonModal>
           ) : null}
           {_showApplicationAlert ? <SystemMessage></SystemMessage> : null}
+          {_showCartModal ? <CartModal></CartModal> : null}
         </div>
       ) : (
         <div className="App">

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -7,7 +7,8 @@ import {
   setShowPublishModal,
   setshowUploadGeojsonModal,
   setshowApplicationAlert,
-  setappConfig
+  setappConfig,
+  setshowCartModal
 } from './redux/slices/mainSlice'
 import { vi } from 'vitest'
 import * as CollectionsService from './services/get-collections-service'
@@ -90,6 +91,19 @@ describe('App', () => {
         setup()
         const SystemMessageComponent = screen.queryByTestId('testSystemMessage')
         expect(SystemMessageComponent).not.toBeNull()
+      })
+    })
+    describe('when conditionally rendering Cart Modal', () => {
+      it('should not render CartModal if showCartModal in state is false', () => {
+        setup()
+        const CartModalComponent = screen.queryByTestId('testCartModal')
+        expect(CartModalComponent).toBeNull()
+      })
+      it('should render CartModal if showCartModal in state is true', () => {
+        store.dispatch(setshowCartModal(true))
+        setup()
+        const CartModalComponent = screen.queryByTestId('testCartModal')
+        expect(CartModalComponent).not.toBeNull()
       })
     })
   })

--- a/src/components/Cart/CartModal/CartModal.css
+++ b/src/components/Cart/CartModal/CartModal.css
@@ -1,0 +1,62 @@
+.cartModal {
+  background-color: #00000090;
+  height: 100%;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: absolute;
+  z-index: 100;
+}
+
+.cartModalContents {
+  position: absolute;
+  z-index: 1;
+  height: 90%;
+  width: 95%;
+  min-height: 300px;
+  min-width: 500px;
+  background-color: #13171a;
+  border-radius: 5px;
+}
+
+.cartModalTopBar {
+  position: absolute;
+  top: 0px;
+  height: 50px;
+  width: 100%;
+  align-items: center;
+  background-color: #6cc24a;
+  color: #000;
+  display: flex;
+  flex-direction: row;
+  font-size: 18px;
+  font-weight: bold;
+  border-top-left-radius: 5px;
+  border-top-right-radius: 5px;
+  justify-content: space-between;
+}
+
+.cartModalTopBarText {
+  margin-left: 15px;
+}
+
+.closeCartModal {
+  background-color: transparent;
+  color: #000;
+  border: 0px;
+  font-size: 24px;
+  cursor: pointer;
+  -webkit-touch-callout: none;
+  /* iOS Safari */
+  -webkit-user-select: none;
+  /* Safari */
+  -khtml-user-select: none;
+  /* Konqueror HTML */
+  -moz-user-select: none;
+  /* Old versions of Firefox */
+  -ms-user-select: none;
+  /* Internet Explorer/Edge */
+  user-select: none;
+  margin-right: 15px;
+}

--- a/src/components/Cart/CartModal/CartModal.jsx
+++ b/src/components/Cart/CartModal/CartModal.jsx
@@ -10,7 +10,7 @@ const CartModal = () => {
     dispatch(setshowCartModal(false))
   }
   return (
-    <div className="cartModal">
+    <div className="cartModal" data-testid="testCartModal">
       <div className="cartModalContents">
         <div className="cartModalTopBar">
           <span className="cartModalTopBarText">Your cart</span>

--- a/src/components/Cart/CartModal/CartModal.jsx
+++ b/src/components/Cart/CartModal/CartModal.jsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import './CartModal.css'
+import { useDispatch } from 'react-redux'
+import { setshowCartModal } from '../../../redux/slices/mainSlice'
+
+const CartModal = () => {
+  const dispatch = useDispatch()
+
+  function onCartModalCloseClick() {
+    dispatch(setshowCartModal(false))
+  }
+  return (
+    <div className="cartModal">
+      <div className="cartModalContents">
+        <div className="cartModalTopBar">
+          <span className="cartModalTopBarText">Your cart</span>
+          <button
+            className="closeCartModal"
+            onClick={() => onCartModalCloseClick()}
+          >
+            ✕
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default CartModal

--- a/src/components/Cart/CartModal/CartModal.test.jsx
+++ b/src/components/Cart/CartModal/CartModal.test.jsx
@@ -1,10 +1,9 @@
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { Provider } from 'react-redux'
 import { store } from '../../../redux/store'
 import { setappConfig, setshowCartModal } from '../../../redux/slices/mainSlice'
 import { mockAppConfig } from '../../../testing/shared-mocks'
-import userEvent from '@testing-library/user-event'
 import CartModal from './CartModal'
 
 describe('CartModal', () => {
@@ -20,20 +19,12 @@ describe('CartModal', () => {
   })
 
   describe('on close clicked', () => {
-    it('should set setshowCartModal to false in redux state', async () => {
-      const mockAppConfigSearchEnabled = {
-        ...mockAppConfig,
-        CART_ENABLED: true
-      }
-      store.dispatch(setappConfig(mockAppConfigSearchEnabled))
+    it('should set setshowCartModal to false in redux state', () => {
       store.dispatch(setshowCartModal(true))
       setup()
       expect(store.getState().mainSlice.showCartModal).toBeTruthy()
-      await userEvent.click(
-        screen.getByRole('button', {
-          name: /✕/i
-        })
-      )
+      const closeButton = screen.getByText('✕')
+      fireEvent.click(closeButton)
       expect(store.getState().mainSlice.showCartModal).toBeFalsy()
     })
   })

--- a/src/components/Cart/CartModal/CartModal.test.jsx
+++ b/src/components/Cart/CartModal/CartModal.test.jsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { store } from '../../../redux/store'
+import { setappConfig, setshowCartModal } from '../../../redux/slices/mainSlice'
+import { mockAppConfig } from '../../../testing/shared-mocks'
+import userEvent from '@testing-library/user-event'
+import CartModal from './CartModal'
+
+describe('CartModal', () => {
+  const setup = () =>
+    render(
+      <Provider store={store}>
+        <CartModal />
+      </Provider>
+    )
+
+  beforeEach(() => {
+    store.dispatch(setappConfig(mockAppConfig))
+  })
+
+  describe('on close clicked', () => {
+    it('should set setshowCartModal to false in redux state', async () => {
+      store.dispatch(setshowCartModal(true))
+      setup()
+      expect(store.getState().mainSlice.showCartModal).toBeTruthy()
+      await userEvent.click(
+        screen.getByRole('button', {
+          name: /✕/i
+        })
+      )
+      expect(store.getState().mainSlice.showCartModal).toBeFalsy()
+    })
+  })
+})

--- a/src/components/Cart/CartModal/CartModal.test.jsx
+++ b/src/components/Cart/CartModal/CartModal.test.jsx
@@ -21,6 +21,11 @@ describe('CartModal', () => {
 
   describe('on close clicked', () => {
     it('should set setshowCartModal to false in redux state', async () => {
+      const mockAppConfigSearchEnabled = {
+        ...mockAppConfig,
+        CART_ENABLED: true
+      }
+      store.dispatch(setappConfig(mockAppConfigSearchEnabled))
       store.dispatch(setshowCartModal(true))
       setup()
       expect(store.getState().mainSlice.showCartModal).toBeTruthy()

--- a/src/components/CollectionDropdown/CollectionDropdown.css
+++ b/src/components/CollectionDropdown/CollectionDropdown.css
@@ -25,5 +25,5 @@
 .collectionDropdown div[label='Collection'] {
   top: -2.5px;
   padding-top: 1px;
-  width: 300px;
+  min-width: 150px;
 }

--- a/src/components/CollectionDropdown/CollectionDropdown.css
+++ b/src/components/CollectionDropdown/CollectionDropdown.css
@@ -25,5 +25,5 @@
 .collectionDropdown div[label='Collection'] {
   top: -2.5px;
   padding-top: 1px;
-  min-width: 150px;
+  min-width: 100%;
 }

--- a/src/components/CollectionDropdown/CollectionDropdown.jsx
+++ b/src/components/CollectionDropdown/CollectionDropdown.jsx
@@ -63,11 +63,7 @@ const Dropdown = () => {
   return (
     <Box>
       <label htmlFor="collectionDropdown">Collection</label>
-      <Grid
-        container
-        alignItems="center"
-        className="collectionDropdownContainer"
-      >
+      <Grid container alignItems="center">
         <Grid item xs>
           <NativeSelect
             id="collectionDropdown"

--- a/src/components/CollectionDropdown/CollectionDropdown.jsx
+++ b/src/components/CollectionDropdown/CollectionDropdown.jsx
@@ -63,7 +63,11 @@ const Dropdown = () => {
   return (
     <Box>
       <label htmlFor="collectionDropdown">Collection</label>
-      <Grid container alignItems="center">
+      <Grid
+        container
+        alignItems="center"
+        className="collectionDropdownContainer"
+      >
         <Grid item xs>
           <NativeSelect
             id="collectionDropdown"

--- a/src/components/DateTimeRangeSelector/DateTimeRangeSelector.css
+++ b/src/components/DateTimeRangeSelector/DateTimeRangeSelector.css
@@ -12,7 +12,7 @@ label {
 .datePicker {
   z-index: 4;
   font-size: 16px;
-  min-width: 270px;
+  min-width: 150px;
 }
 
 .datePicker label a svg {
@@ -40,7 +40,7 @@ label {
   flex-direction: column;
   justify-content: center;
   flex-grow: 1;
-  width: 100%;
+  width: 80%;
 }
 
 .dateToolTipIcon {

--- a/src/components/Layout/Content/BottomContent/BottomContent.css
+++ b/src/components/Layout/Content/BottomContent/BottomContent.css
@@ -175,9 +175,6 @@
   opacity: 0.75;
 }
 
-@media screen and (max-width: 730px) {
-}
-
 @media screen and (max-width: 1460px) {
   .BottomContent {
     height: calc(100% - 200px);

--- a/src/components/Layout/Content/BottomContent/BottomContent.css
+++ b/src/components/Layout/Content/BottomContent/BottomContent.css
@@ -176,6 +176,22 @@
 }
 
 @media screen and (max-width: 730px) {
+}
+
+@media screen and (max-width: 1460px) {
+  .BottomContent {
+    height: calc(100% - 200px);
+    margin-top: 100px;
+  }
+}
+
+@media screen and (max-width: 975px) {
+  .BottomContent {
+    height: calc(100% - 60px);
+    top: 0px;
+    margin-top: 60px;
+    background-color: red;
+  }
   .BottomContent {
     height: calc(100% - 60px);
     margin-top: 60px;
@@ -183,19 +199,11 @@
 
   .resultCount {
     width: 70%;
-    top: 50px;
     left: 52px;
     transform: none;
   }
 
   .ZoomNotice {
     width: 70%;
-  }
-}
-
-@media screen and (max-width: 1460px) {
-  .BottomContent {
-    height: calc(100% - 200px);
-    margin-top: 100px;
   }
 }

--- a/src/components/Layout/Content/BottomContent/BottomContent.css
+++ b/src/components/Layout/Content/BottomContent/BottomContent.css
@@ -192,3 +192,10 @@
     width: 70%;
   }
 }
+
+@media screen and (max-width: 1460px) {
+  .BottomContent {
+    height: calc(100% - 200px);
+    margin-top: 100px;
+  }
+}

--- a/src/components/Layout/Content/TopContent/TopContent.css
+++ b/src/components/Layout/Content/TopContent/TopContent.css
@@ -37,10 +37,11 @@
   transform: rotate(180deg);
 }
 
-@media screen and (max-width: 730px) {
+@media screen and (max-width: 975px) {
   .TopContent {
     position: absolute;
-    z-index: 9999;
+    z-index: 99;
+    height: auto;
   }
   .TopContent.active .Search {
     max-height: 100vh;
@@ -51,13 +52,7 @@
   }
 }
 
-@media screen and (max-width: 1299px) {
-  .TopContent {
-    height: auto;
-  }
-}
-
-@media screen and (min-width: 731px) {
+@media screen and (min-width: 975px) {
   .TopContent .mobileMenu {
     display: none;
   }

--- a/src/components/Legend/LayerLegend/LayerLegend.css
+++ b/src/components/Legend/LayerLegend/LayerLegend.css
@@ -13,6 +13,10 @@
   opacity: 0.9;
 }
 
+.LayerLegendBottom {
+  bottom: 20px;
+}
+
 .hexLegendContainer {
   display: flex;
   flex-direction: column;

--- a/src/components/Legend/LayerLegend/LayerLegend.jsx
+++ b/src/components/Legend/LayerLegend/LayerLegend.jsx
@@ -11,7 +11,16 @@ const LayerLegend = () => {
   )
   const _searchResults = useSelector((state) => state.mainSlice.searchResults)
   return (
-    <div data-testid="testLayerLegend" className="LayerLegend">
+    <div
+      data-testid="testLayerLegend"
+      className={
+        _appConfig.SHOW_PUBLISH_BTN ||
+        _appConfig.ANALYZE_BTN_URL ||
+        _appConfig.LAUNCH_URL
+          ? 'LayerLegend'
+          : 'LayerLegend LayerLegendBottom'
+      }
+    >
       {_searchType === 'scene' && (
         <div className="sceneLegend">
           {_appConfig.CART_ENABLED ? (

--- a/src/components/Search/Search.css
+++ b/src/components/Search/Search.css
@@ -290,6 +290,27 @@
   }
 }
 
+@media screen and (max-width: 975px) {
+  .Search {
+    flex-direction: column;
+    height: 200px;
+  }
+  .firstSearchItemsGroup {
+    width: 100%;
+    flex-direction: column;
+  }
+  .secondSearchItemsGroup {
+    width: 100%;
+    flex-direction: column;
+  }
+  .searchButtonAdvanced.active {
+    z-index: 100;
+  }
+  .disableSearchOverlay {
+    display: none;
+  }
+}
+
 /* Date Range Picker */
 
 .datePicker {

--- a/src/components/Search/Search.css
+++ b/src/components/Search/Search.css
@@ -6,18 +6,28 @@
   transition: max-height 0.33s ease-in-out;
 }
 
+.firstSearchItemsGroup {
+  display: flex;
+  flex-direction: row;
+  width: 65%;
+}
+.secondSearchItemsGroup {
+  display: flex;
+  flex-direction: row;
+  width: 35%;
+}
+
 .searchContainer {
   height: 100px;
-  padding-left: 2%;
-  padding-right: 2%;
   background-color: #353d4f;
   color: #ffffff;
   font-size: 16px;
   display: flex;
   flex-direction: column;
   justify-content: center;
-  flex-grow: 1;
+  align-items: center;
   width: 100%;
+  border-right: 2px solid rgba(0, 0, 0, 0.2);
 }
 
 .searchContainer label {
@@ -34,48 +44,66 @@
   padding-top: 5px;
 }
 
-.searchContainer .cloudSlider {
-  min-width: 155px;
+.collectionDropdownComponent {
+  width: 80%;
+}
+
+.dateTimeRangeComponent {
+  width: 80%;
+}
+
+.cloudSliderComponent {
+  width: 80%;
+}
+.viewSelectorComponent {
+  width: 80%;
+  display: flex;
+  justify-content: center;
+}
+
+.cartComponent {
+  width: 80%;
+}
+
+.defaultSearchContainer {
+  display: flex;
+  flex-direction: column;
 }
 
 .searchContainer.searchButton {
-  border-right: 0 none;
-  flex-direction: row;
+  flex-direction: column;
   align-items: center;
-  justify-content: flex-start;
+  justify-content: center;
 }
-
-.searchContainer.searchButtonAdvanced {
-  padding-left: 40px;
-  padding-right: 40px;
+.searchContainer.searchButton .actionButton {
+  height: 45px;
 }
 
 .searchContainer.searchButtonAdvanced.active {
   background-color: #4f5768;
-  width: 150px;
   display: block;
 }
 
 .advancedSearchContent {
-  width: 150px;
+  width: 100%;
   height: 100px;
   display: flex;
   flex-direction: column;
   justify-content: center;
+  align-items: center;
 }
 
 .advancedSearchOptionsContainer {
   height: 167px;
-  width: 280px;
+  width: 100%;
   background-color: #4f5768;
-  float: right;
-  margin-right: -40px;
   display: flex;
   flex-direction: column;
+  border-right: 2px solid rgba(0, 0, 0, 0.2);
 }
 
 .advancedSearchOptionsText {
-  font-size: 16px;
+  font-size: 14px;
   margin-top: 10px;
   margin-left: 12px;
   color: #fff;
@@ -92,14 +120,14 @@
 
 .advancedSearchOptionsButton {
   height: 32px;
-  width: 256px;
+  width: 80%;
   background-color: #4f5768;
   border: none;
   color: white;
-  padding: 15px 32px;
+  padding: 15px 15px;
   text-align: center;
   text-decoration: none;
-  font-size: 16px;
+  font-size: 14px;
   cursor: pointer;
   border: 1px solid #a9b0c1;
   margin-bottom: 10px;
@@ -145,6 +173,8 @@
   min-width: 160px;
   align-items: center;
   padding-top: 2px;
+  margin-top: -5px;
+  margin-bottom: -10px;
 }
 
 .advancedSearchOptions {
@@ -161,6 +191,10 @@
 
 .searchContainer .actionButton {
   height: 45px;
+  width: 145px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .disableSearchOverlay {
@@ -172,23 +206,87 @@
   position: absolute;
 }
 
-@media screen and (min-width: 731px) {
+.cartButtonContainer {
+  max-width: 130px;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  cursor: default;
+}
+
+.cartButton {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 60px;
+  width: 55px;
+  border-radius: 5px;
+  border-style: solid;
+  border-width: 1px;
+  padding: 10px;
+  font-size: 18px;
+  font-weight: bold;
+  border-color: #76829c;
+  color: #a9b0c1;
+  user-select: none;
+  margin-right: 10px;
+}
+
+.cartButtonEnabled {
+  cursor: pointer;
+  color: #12171a;
+  background-color: #6cc24a;
+  border-style: none;
+}
+
+.cartCountContainer {
+  width: 55px;
+  height: 30px;
+  background-color: #5d626d;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 7px;
+  border-radius: 5px;
+  font-weight: normal;
+}
+
+.carCountContainerEnabled {
+  background-color: #4f8f36;
+}
+
+/* @media screen and (min-width: 731px) {
   .Search {
     height: 100%;
   }
   .searchContainer {
     width: unset;
     flex-grow: unset;
-    border-right: 2px solid rgba(0, 0, 0, 0.2);
   }
-}
+} */
 
-@media screen and (max-width: 1299px) {
+@media screen and (max-width: 1460px) {
   .Search {
-    flex-wrap: wrap;
+    flex-direction: column;
+    height: 200px;
+  }
+  .firstSearchItemsGroup {
+    width: 100%;
+  }
+  .secondSearchItemsGroup {
+    width: 100%;
   }
   .searchContainer {
     border-bottom: 2px solid rgba(0, 0, 0, 0.2);
+  }
+  .cartButtonContainer {
+    max-width: unset;
+    align-items: center;
+  }
+  .defaultSearchContainer {
+    min-width: unset;
   }
 }
 

--- a/src/components/Search/Search.css
+++ b/src/components/Search/Search.css
@@ -291,13 +291,20 @@
   }
   .secondSearchItemsGroup {
     width: 100%;
-    flex-direction: column;
+    flex-direction: row;
   }
   .searchButtonAdvanced.active {
     z-index: 100;
   }
   .disableSearchOverlay {
     display: none;
+  }
+}
+
+@media screen and (max-width: 600px) {
+  .secondSearchItemsGroup {
+    width: 100%;
+    flex-direction: column;
   }
 }
 

--- a/src/components/Search/Search.css
+++ b/src/components/Search/Search.css
@@ -257,16 +257,6 @@
   background-color: #4f8f36;
 }
 
-/* @media screen and (min-width: 731px) {
-  .Search {
-    height: 100%;
-  }
-  .searchContainer {
-    width: unset;
-    flex-grow: unset;
-  }
-} */
-
 @media screen and (max-width: 1460px) {
   .Search {
     flex-direction: column;
@@ -368,7 +358,7 @@ input[class$='-MuiInputBase-input-MuiInput-input'] {
   max-width: 30%;
 }
 
-@media screen and (max-width: 730px) {
+@media screen and (max-width: 975px) {
   .leaflet-control-geosearch.leaflet-geosearch-bar {
     max-width: 80%;
   }

--- a/src/components/Search/Search.jsx
+++ b/src/components/Search/Search.jsx
@@ -6,7 +6,8 @@ import {
   setshowAdvancedSearchOptions,
   setisDrawingEnabled,
   setsearchGeojsonBoundary,
-  setshowUploadGeojsonModal
+  setshowUploadGeojsonModal,
+  setshowCartModal
 } from '../../redux/slices/mainSlice'
 import 'react-tooltip/dist/react-tooltip.css'
 import Switch from '@mui/material/Switch'
@@ -43,6 +44,7 @@ const Search = () => {
     (state) => state.mainSlice.searchGeojsonBoundary
   )
   const _appConfig = useSelector((state) => state.mainSlice.appConfig)
+  const _cartItems = useSelector((state) => state.mainSlice.cartItems)
   const mosaicTilerURL = _appConfig.MOSAIC_TILER_URL || ''
 
   useEffect(() => {
@@ -100,118 +102,162 @@ const Search = () => {
     }
   }
 
+  function onCartButtonClick() {
+    if (_cartItems.length === 0) {
+      return
+    }
+    dispatch(setshowCartModal(true))
+  }
+
   return (
     <div className="Search" data-testid="Search">
-      <div className={`searchContainer collectionDropdown`}>
-        <CollectionDropdown></CollectionDropdown>
-      </div>
-      <div className="searchContainer datePicker">
-        <DateTimeRangeSelector></DateTimeRangeSelector>
-      </div>
-      <div className="searchContainer cloudSlider">
-        <CloudSlider></CloudSlider>
-      </div>
-      {mosaicTilerURL && (
-        <div className="searchContainer">
-          <ViewSelector></ViewSelector>
-        </div>
-      )}
-
-      {_appConfig.ADVANCED_SEARCH_ENABLED ? (
-        <Box
-          className={
-            _showAdvancedSearchOptions
-              ? 'searchContainer searchButtonAdvanced ' + 'active'
-              : 'searchContainer searchButtonAdvanced'
-          }
-          onBlur={onAdvancedSearchBlur}
-          tabIndex={0}
-        >
-          <div className="advancedSearchContent">
-            <button
-              className={`actionButton`}
-              onClick={() => processSearchBtn()}
-            >
-              Search
-            </button>
-            <Box
-              className="advancedSearchOptions"
-              onClick={onAdvancedOptionsClicked}
-            >
-              Advanced
-              {_showAdvancedSearchOptions ? (
-                <KeyboardArrowUpIcon></KeyboardArrowUpIcon>
-              ) : (
-                <KeyboardArrowDownIcon></KeyboardArrowDownIcon>
-              )}
-            </Box>
+      <div className="firstSearchItemsGroup">
+        <div className={`searchContainer collectionDropdown`}>
+          <div className="collectionDropdownComponent">
+            <CollectionDropdown></CollectionDropdown>
           </div>
-          {_showAdvancedSearchOptions ? (
-            <Box className="advancedSearchOptionsContainer">
-              <span className="advancedSearchOptionsText">
-                Limit search to boundary
-              </span>
-              <div className="advancedSearchOptionsButtons">
-                <button
-                  className={
-                    !_searchGeojsonBoundary
-                      ? 'advancedSearchOptionsButton'
-                      : 'advancedSearchOptionsButton ' +
-                        'advancedSearchOptionsButtonDisabled'
-                  }
-                  onClick={onDrawBoundaryClicked}
-                >
-                  Draw boundary
-                </button>
-                <button
-                  className={
-                    !_searchGeojsonBoundary
-                      ? 'advancedSearchOptionsButton'
-                      : 'advancedSearchOptionsButton ' +
-                        'advancedSearchOptionsButtonDisabled'
-                  }
-                  onClick={onUploadGeojsonButtonClicked}
-                >
-                  Upload GeoJSON
-                </button>
-                <button
-                  className={
-                    _searchGeojsonBoundary
-                      ? 'advancedSearchOptionsButton'
-                      : 'advancedSearchOptionsButton ' +
-                        'advancedSearchOptionsButtonDisabled'
-                  }
-                  onClick={onClearButtonClicked}
-                >
-                  Clear
-                </button>
+        </div>
+        <div className="searchContainer datePicker">
+          <div className="dateTimeRangeComponent">
+            <DateTimeRangeSelector></DateTimeRangeSelector>
+          </div>
+        </div>
+        <div className="searchContainer cloudSlider">
+          <div className="cloudSliderComponent">
+            <CloudSlider></CloudSlider>
+          </div>
+        </div>
+      </div>
+      <div className="secondSearchItemsGroup">
+        {mosaicTilerURL && (
+          <div className="searchContainer">
+            <div className="viewSelectorComponent">
+              <ViewSelector></ViewSelector>
+            </div>
+          </div>
+        )}
+        {_appConfig.ADVANCED_SEARCH_ENABLED ? (
+          <Box
+            className={
+              _showAdvancedSearchOptions
+                ? 'searchContainer searchButtonAdvanced ' + 'active'
+                : 'searchContainer searchButtonAdvanced'
+            }
+            onBlur={onAdvancedSearchBlur}
+            tabIndex={0}
+          >
+            <div className="advancedSearchContent">
+              <button
+                className={`actionButton`}
+                onClick={() => processSearchBtn()}
+              >
+                Search
+              </button>
+              <Box
+                className="advancedSearchOptions"
+                onClick={onAdvancedOptionsClicked}
+              >
+                Advanced
+                {_showAdvancedSearchOptions ? (
+                  <KeyboardArrowUpIcon></KeyboardArrowUpIcon>
+                ) : (
+                  <KeyboardArrowDownIcon></KeyboardArrowDownIcon>
+                )}
+              </Box>
+            </div>
+            {_showAdvancedSearchOptions ? (
+              <Box className="advancedSearchOptionsContainer">
+                <span className="advancedSearchOptionsText">
+                  Limit search to boundary
+                </span>
+                <div className="advancedSearchOptionsButtons">
+                  <button
+                    className={
+                      !_searchGeojsonBoundary
+                        ? 'advancedSearchOptionsButton'
+                        : 'advancedSearchOptionsButton ' +
+                          'advancedSearchOptionsButtonDisabled'
+                    }
+                    onClick={onDrawBoundaryClicked}
+                  >
+                    Draw boundary
+                  </button>
+                  <button
+                    className={
+                      !_searchGeojsonBoundary
+                        ? 'advancedSearchOptionsButton'
+                        : 'advancedSearchOptionsButton ' +
+                          'advancedSearchOptionsButtonDisabled'
+                    }
+                    onClick={onUploadGeojsonButtonClicked}
+                  >
+                    Upload GeoJSON
+                  </button>
+                  <button
+                    className={
+                      _searchGeojsonBoundary
+                        ? 'advancedSearchOptionsButton'
+                        : 'advancedSearchOptionsButton ' +
+                          'advancedSearchOptionsButtonDisabled'
+                    }
+                    onClick={onClearButtonClicked}
+                  >
+                    Clear
+                  </button>
+                </div>
+              </Box>
+            ) : null}
+          </Box>
+        ) : (
+          <div className="searchContainer searchButton defaultSearchContainer">
+            <div>
+              <button
+                className={`actionButton disabled-${_isAutoSearchSet}`}
+                onClick={() => processSearchBtn()}
+                disabled={_isAutoSearchSet}
+              >
+                Search
+              </button>
+            </div>
+
+            <div
+              className="autoSearchContainer"
+              data-testid="test_autoSearchContainer"
+            >
+              <label htmlFor="autoSearchSwtich">Auto Search</label>
+              <Switch
+                checked={_isAutoSearchSet}
+                onChange={handleSwitchChange}
+                inputProps={{ 'aria-label': 'controlled' }}
+              />
+            </div>
+          </div>
+        )}
+        {_appConfig.CART_ENABLED ? (
+          <div className="searchContainer cartButtonContainer">
+            <div className="cartComponent"></div>
+            <Box
+              className={
+                _cartItems.length > 0
+                  ? 'cartButton cartButtonEnabled'
+                  : 'cartButton'
+              }
+              onClick={onCartButtonClick}
+            >
+              <span>Cart</span>
+              <div
+                className={
+                  _cartItems.length > 0
+                    ? 'cartCountContainer carCountContainerEnabled'
+                    : 'cartCountContainer'
+                }
+              >
+                {_cartItems.length}
               </div>
             </Box>
-          ) : null}
-        </Box>
-      ) : (
-        <div className="searchContainer searchButton">
-          <button
-            className={`actionButton disabled-${_isAutoSearchSet}`}
-            onClick={() => processSearchBtn()}
-            disabled={_isAutoSearchSet}
-          >
-            Search
-          </button>
-
-          <div
-            className="autoSearchContainer"
-            data-testid="test_autoSearchContainer"
-          >
-            <label htmlFor="autoSearchSwtich">Auto Search</label>
-            <Switch
-              checked={_isAutoSearchSet}
-              onChange={handleSwitchChange}
-              inputProps={{ 'aria-label': 'controlled' }}
-            />
           </div>
-        </div>
-      )}
+        ) : null}
+      </div>
       {_isDrawingEnabled ? (
         <div
           className="disableSearchOverlay"

--- a/src/components/Search/Search.jsx
+++ b/src/components/Search/Search.jsx
@@ -242,6 +242,7 @@ const Search = () => {
                   ? 'cartButton cartButtonEnabled'
                   : 'cartButton'
               }
+              data-testid="testCartButton"
               onClick={onCartButtonClick}
             >
               <span>Cart</span>
@@ -251,6 +252,7 @@ const Search = () => {
                     ? 'cartCountContainer carCountContainerEnabled'
                     : 'cartCountContainer'
                 }
+                data-testid="testCartCount"
               >
                 {_cartItems.length}
               </div>

--- a/src/components/Search/Search.test.jsx
+++ b/src/components/Search/Search.test.jsx
@@ -6,6 +6,7 @@ import { Provider } from 'react-redux'
 import { store } from '../../redux/store'
 import {
   setappConfig,
+  setcartItems,
   setCloudCover,
   setsearchGeojsonBoundary,
   setshowAdvancedSearchOptions
@@ -27,185 +28,254 @@ describe('Search', () => {
     vi.resetAllMocks()
   })
 
-  describe('if advanced search enabled is false', () => {
-    beforeEach(() => {
-      store.dispatch(setappConfig(mockAppConfig))
+  describe('search button', () => {
+    describe('if advanced search enabled is false', () => {
+      beforeEach(() => {
+        store.dispatch(setappConfig(mockAppConfig))
+      })
+      describe('on render', () => {
+        it('should render auto search when ADVANCED_SEARCH_ENABLED is false', () => {
+          setup()
+          expect(screen.getByText(/auto search/i)).toBeInTheDocument()
+        })
+      })
     })
-    describe('on render', () => {
-      it('should render auto search when ADVANCED_SEARCH_ENABLED is false', () => {
-        setup()
-        expect(screen.getByText(/auto search/i)).toBeInTheDocument()
+    describe('if advanced search enabled is true', () => {
+      beforeEach(() => {
+        vi.mock('../../utils/mapHelper')
+        vi.mock('../../utils/searchHelper')
+        const mockAppConfigSearchEnabled = {
+          ...mockAppConfig,
+          ADVANCED_SEARCH_ENABLED: true
+        }
+        store.dispatch(setappConfig(mockAppConfigSearchEnabled))
+      })
+      describe('on render', () => {
+        it('should not render auto search when ADVANCED_SEARCH_ENABLED is true', () => {
+          setup()
+          expect(
+            screen.queryByText('test_autoSearchContainer')
+          ).not.toBeInTheDocument()
+        })
+        it('should not render disabled search bar overlay div', async () => {
+          setup()
+          expect(
+            screen.queryByTestId('test_disableSearchOverlay')
+          ).not.toBeInTheDocument()
+        })
+      })
+      describe('when search options changed', () => {
+        it('should set showAdvancedSearchOptions to false in redux', () => {
+          store.dispatch(setshowAdvancedSearchOptions(true))
+          setup()
+          store.dispatch(setCloudCover(5))
+          expect(
+            store.getState().mainSlice.showAdvancedSearchOptions
+          ).toBeFalsy()
+        })
+      })
+      describe('when search button clicked', () => {
+        it('should set showAdvancedSearchOptions to false in redux', async () => {
+          store.dispatch(setshowAdvancedSearchOptions(true))
+          setup()
+          const searchButton = screen.getByRole('button', {
+            name: /search/i
+          })
+          await user.click(searchButton)
+          expect(
+            store.getState().mainSlice.showAdvancedSearchOptions
+          ).toBeFalsy()
+        })
+      })
+      describe('when advanced clicked', () => {
+        it('should set showAdvancedSearchOptions be the opposite showAdvancedSearchOptions of in redux', async () => {
+          setup()
+          const advancedButton = screen.getByText(/advanced/i)
+          await user.click(advancedButton)
+          expect(
+            store.getState().mainSlice.showAdvancedSearchOptions
+          ).toBeTruthy()
+          await user.click(advancedButton)
+          expect(
+            store.getState().mainSlice.showAdvancedSearchOptions
+          ).toBeFalsy()
+        })
+      })
+      describe('when draw boundary button clicked', () => {
+        it('should not call functions if geom already exists', async () => {
+          const spyEnableMapPolyDrawing = vi.spyOn(
+            mapHelper,
+            'enableMapPolyDrawing'
+          )
+          store.dispatch(
+            setsearchGeojsonBoundary({
+              type: 'Polygon',
+              coordinates: [[]]
+            })
+          )
+          setup()
+          const advancedButton = screen.getByText(/advanced/i)
+          await user.click(advancedButton)
+          const drawBoundaryButton = screen.getByRole('button', {
+            name: /draw boundary/i
+          })
+          await user.click(drawBoundaryButton)
+          expect(spyEnableMapPolyDrawing).not.toHaveBeenCalled()
+        })
+        it('should enter drawing state if geom does not exists', async () => {
+          const spyEnableMapPolyDrawing = vi.spyOn(
+            mapHelper,
+            'enableMapPolyDrawing'
+          )
+          store.dispatch(setshowAdvancedSearchOptions(true))
+          setup()
+          const advancedButton = screen.getByText(/advanced/i)
+          await user.click(advancedButton)
+          const drawBoundaryButton = screen.getByRole('button', {
+            name: /draw boundary/i
+          })
+          await user.click(drawBoundaryButton)
+          expect(spyEnableMapPolyDrawing).toHaveBeenCalled()
+          expect(
+            store.getState().mainSlice.showAdvancedSearchOptions
+          ).toBeFalsy()
+          expect(store.getState().mainSlice.isDrawingEnabled).toBeTruthy()
+        })
+      })
+      describe('when clear button clicked', () => {
+        it('should not call functions if geom does not exists', async () => {
+          const spyClearLayer = vi.spyOn(mapHelper, 'clearLayer')
+          setup()
+          const advancedButton = screen.getByText(/advanced/i)
+          await user.click(advancedButton)
+          const clearButton = screen.getByRole('button', {
+            name: /clear/i
+          })
+          await user.click(clearButton)
+          expect(spyClearLayer).not.toHaveBeenCalled()
+        })
+        it('should clear layer and close options if geom exists', async () => {
+          const spyClearLayer = vi.spyOn(mapHelper, 'clearLayer')
+          store.dispatch(
+            setsearchGeojsonBoundary({
+              type: 'Polygon',
+              coordinates: [[]]
+            })
+          )
+          setup()
+          const advancedButton = screen.getByText(/advanced/i)
+          await user.click(advancedButton)
+          const clearButton = screen.getByRole('button', {
+            name: /clear/i
+          })
+          await user.click(clearButton)
+          expect(spyClearLayer).toHaveBeenCalled()
+          expect(store.getState().mainSlice.searchGeojsonBoundary).toBeNull()
+          expect(
+            store.getState().mainSlice.showAdvancedSearchOptions
+          ).toBeFalsy()
+        })
+      })
+      describe('when upload geojson button clicked', () => {
+        it('should not call dispatch functions if geom already exists', async () => {
+          store.dispatch(
+            setsearchGeojsonBoundary({
+              type: 'Polygon',
+              coordinates: [[]]
+            })
+          )
+          setup()
+          const advancedButton = screen.getByText(/advanced/i)
+          await user.click(advancedButton)
+          const uploadGeojsonButton = screen.getByRole('button', {
+            name: /upload geojson/i
+          })
+          await user.click(uploadGeojsonButton)
+          expect(store.getState().mainSlice.showUploadGeojsonModal).toBeFalsy()
+        })
+        it('should call dispatch functions if geom does not exists', async () => {
+          store.dispatch(setshowAdvancedSearchOptions(true))
+          setup()
+          const advancedButton = screen.getByText(/advanced/i)
+          await user.click(advancedButton)
+          const uploadGeojsonButton = screen.getByRole('button', {
+            name: /upload geojson/i
+          })
+          await user.click(uploadGeojsonButton)
+          expect(
+            store.getState().mainSlice.showAdvancedSearchOptions
+          ).toBeFalsy()
+          expect(store.getState().mainSlice.showUploadGeojsonModal).toBeTruthy()
+        })
+      })
+      describe('when drawing mode enabled', () => {
+        it('should render disabled search bar overlay div', async () => {
+          setup()
+          const advancedButton = screen.getByText(/advanced/i)
+          await user.click(advancedButton)
+          const drawBoundaryButton = screen.getByRole('button', {
+            name: /draw boundary/i
+          })
+          await user.click(drawBoundaryButton)
+          expect(
+            screen.queryByTestId('test_disableSearchOverlay')
+          ).toBeInTheDocument()
+        })
       })
     })
   })
-  describe('if advanced search enabled is true', () => {
-    beforeEach(() => {
-      vi.mock('../../utils/mapHelper')
-      vi.mock('../../utils/searchHelper')
-      const mockAppConfigSearchEnabled = {
-        ...mockAppConfig,
-        ADVANCED_SEARCH_ENABLED: true
-      }
-      store.dispatch(setappConfig(mockAppConfigSearchEnabled))
-    })
-    describe('on render', () => {
-      it('should not render auto search when ADVANCED_SEARCH_ENABLED is true', () => {
-        setup()
-        expect(
-          screen.queryByText('test_autoSearchContainer')
-        ).not.toBeInTheDocument()
+
+  describe('cart button', () => {
+    describe('if cartEnabled is set to false in config', () => {
+      beforeEach(() => {
+        store.dispatch(setappConfig(mockAppConfig))
       })
-      it('should not render disabled search bar overlay div', async () => {
-        setup()
-        expect(
-          screen.queryByTestId('test_disableSearchOverlay')
-        ).not.toBeInTheDocument()
+      describe('on render', () => {
+        it('should not render cart button when CART_ENABLED is false', () => {
+          setup()
+          expect(screen.queryByText(/cart/i)).not.toBeInTheDocument()
+        })
       })
     })
-    describe('when search options changed', () => {
-      it('should set showAdvancedSearchOptions to false in redux', () => {
-        store.dispatch(setshowAdvancedSearchOptions(true))
-        setup()
-        store.dispatch(setCloudCover(5))
-        expect(store.getState().mainSlice.showAdvancedSearchOptions).toBeFalsy()
+    describe('if cartEnabled is set to true in config', () => {
+      beforeEach(() => {
+        const mockAppConfigSearchEnabled = {
+          ...mockAppConfig,
+          CART_ENABLED: true
+        }
+        store.dispatch(setappConfig(mockAppConfigSearchEnabled))
       })
-    })
-    describe('when search button clicked', () => {
-      it('should set showAdvancedSearchOptions to false in redux', async () => {
-        store.dispatch(setshowAdvancedSearchOptions(true))
-        setup()
-        const searchButton = screen.getByRole('button', {
-          name: /search/i
+      describe('on render', () => {
+        it('should render cart button when CART_ENABLED is true', () => {
+          setup()
+          expect(screen.queryByText(/cart/i)).toBeInTheDocument()
         })
-        await user.click(searchButton)
-        expect(store.getState().mainSlice.showAdvancedSearchOptions).toBeFalsy()
       })
-    })
-    describe('when advanced clicked', () => {
-      it('should set showAdvancedSearchOptions be the opposite showAdvancedSearchOptions of in redux', async () => {
-        setup()
-        const advancedButton = screen.getByText(/advanced/i)
-        await user.click(advancedButton)
-        expect(
-          store.getState().mainSlice.showAdvancedSearchOptions
-        ).toBeTruthy()
-        await user.click(advancedButton)
-        expect(store.getState().mainSlice.showAdvancedSearchOptions).toBeFalsy()
-      })
-    })
-    describe('when draw boundary button clicked', () => {
-      it('should not call functions if geom already exists', async () => {
-        const spyEnableMapPolyDrawing = vi.spyOn(
-          mapHelper,
-          'enableMapPolyDrawing'
-        )
-        store.dispatch(
-          setsearchGeojsonBoundary({
-            type: 'Polygon',
-            coordinates: [[]]
-          })
-        )
-        setup()
-        const advancedButton = screen.getByText(/advanced/i)
-        await user.click(advancedButton)
-        const drawBoundaryButton = screen.getByRole('button', {
-          name: /draw boundary/i
+      describe('on cart button click', () => {
+        it('should not open modal if no items in cart', async () => {
+          setup()
+          expect(store.getState().mainSlice.showCartModal).toBeFalsy()
+          await user.click(screen.getByTestId('testCartButton'))
+          expect(store.getState().mainSlice.showCartModal).toBeFalsy()
         })
-        await user.click(drawBoundaryButton)
-        expect(spyEnableMapPolyDrawing).not.toHaveBeenCalled()
-      })
-      it('should enter drawing state if geom does not exists', async () => {
-        const spyEnableMapPolyDrawing = vi.spyOn(
-          mapHelper,
-          'enableMapPolyDrawing'
-        )
-        store.dispatch(setshowAdvancedSearchOptions(true))
-        setup()
-        const advancedButton = screen.getByText(/advanced/i)
-        await user.click(advancedButton)
-        const drawBoundaryButton = screen.getByRole('button', {
-          name: /draw boundary/i
+        it('should open modal if cart has items', async () => {
+          store.dispatch(setcartItems([{ name: 'test item' }]))
+          setup()
+          expect(store.getState().mainSlice.showCartModal).toBeFalsy()
+          await user.click(screen.getByTestId('testCartButton'))
+          expect(store.getState().mainSlice.showCartModal).toBeTruthy()
         })
-        await user.click(drawBoundaryButton)
-        expect(spyEnableMapPolyDrawing).toHaveBeenCalled()
-        expect(store.getState().mainSlice.showAdvancedSearchOptions).toBeFalsy()
-        expect(store.getState().mainSlice.isDrawingEnabled).toBeTruthy()
       })
-    })
-    describe('when clear button clicked', () => {
-      it('should not call functions if geom does not exists', async () => {
-        const spyClearLayer = vi.spyOn(mapHelper, 'clearLayer')
-        setup()
-        const advancedButton = screen.getByText(/advanced/i)
-        await user.click(advancedButton)
-        const clearButton = screen.getByRole('button', {
-          name: /clear/i
+      describe('show count from from cartItems in redux state', () => {
+        it('should show count of 0 items initial redux state', () => {
+          setup()
+          expect(screen.getByTestId('testCartCount').innerHTML).toBe('0')
         })
-        await user.click(clearButton)
-        expect(spyClearLayer).not.toHaveBeenCalled()
-      })
-      it('should clear layer and close options if geom exists', async () => {
-        const spyClearLayer = vi.spyOn(mapHelper, 'clearLayer')
-        store.dispatch(
-          setsearchGeojsonBoundary({
-            type: 'Polygon',
-            coordinates: [[]]
-          })
-        )
-        setup()
-        const advancedButton = screen.getByText(/advanced/i)
-        await user.click(advancedButton)
-        const clearButton = screen.getByRole('button', {
-          name: /clear/i
+        it('should show count of 1 items if redux state changed', () => {
+          store.dispatch(setcartItems([{ name: 'test item' }]))
+          setup()
+          expect(screen.getByTestId('testCartCount').innerHTML).toBe('1')
         })
-        await user.click(clearButton)
-        expect(spyClearLayer).toHaveBeenCalled()
-        expect(store.getState().mainSlice.searchGeojsonBoundary).toBeNull()
-        expect(store.getState().mainSlice.showAdvancedSearchOptions).toBeFalsy()
-      })
-    })
-    describe('when upload geojson button clicked', () => {
-      it('should not call dispatch functions if geom already exists', async () => {
-        store.dispatch(
-          setsearchGeojsonBoundary({
-            type: 'Polygon',
-            coordinates: [[]]
-          })
-        )
-        setup()
-        const advancedButton = screen.getByText(/advanced/i)
-        await user.click(advancedButton)
-        const uploadGeojsonButton = screen.getByRole('button', {
-          name: /upload geojson/i
-        })
-        await user.click(uploadGeojsonButton)
-        expect(store.getState().mainSlice.showUploadGeojsonModal).toBeFalsy()
-      })
-      it('should call dispatch functions if geom does not exists', async () => {
-        store.dispatch(setshowAdvancedSearchOptions(true))
-        setup()
-        const advancedButton = screen.getByText(/advanced/i)
-        await user.click(advancedButton)
-        const uploadGeojsonButton = screen.getByRole('button', {
-          name: /upload geojson/i
-        })
-        await user.click(uploadGeojsonButton)
-        expect(store.getState().mainSlice.showAdvancedSearchOptions).toBeFalsy()
-        expect(store.getState().mainSlice.showUploadGeojsonModal).toBeTruthy()
-      })
-    })
-    describe('when drawing mode enabled', () => {
-      it('should render disabled search bar overlay div', async () => {
-        setup()
-        const advancedButton = screen.getByText(/advanced/i)
-        await user.click(advancedButton)
-        const drawBoundaryButton = screen.getByRole('button', {
-          name: /draw boundary/i
-        })
-        await user.click(drawBoundaryButton)
-        expect(
-          screen.queryByTestId('test_disableSearchOverlay')
-        ).toBeInTheDocument()
       })
     })
   })

--- a/src/redux/slices/mainSlice.js
+++ b/src/redux/slices/mainSlice.js
@@ -32,7 +32,9 @@ const initialState = {
   showApplicationAlert: false,
   applicationAlertMessage: 'System Error',
   applicationAlertSeverity: 'error',
-  appConfig: null
+  appConfig: null,
+  cartItems: [{ test: 'true' }],
+  showCartModal: false
 }
 
 // next, for every key in the initialState
@@ -133,6 +135,12 @@ export const mainSlice = createSlice({
     },
     setappConfig: (state, action) => {
       state.appConfig = action.payload
+    },
+    setcartItems: (state, action) => {
+      state.cartItems = action.payload
+    },
+    setshowCartModal: (state, action) => {
+      state.showCartModal = action.payload
     }
   }
 })
@@ -170,5 +178,7 @@ export const { setshowApplicationAlert } = mainSlice.actions
 export const { setapplicationAlertMessage } = mainSlice.actions
 export const { setapplicationAlertSeverity } = mainSlice.actions
 export const { setappConfig } = mainSlice.actions
+export const { setcartItems } = mainSlice.actions
+export const { setshowCartModal } = mainSlice.actions
 
 export default mainSlice.reducer

--- a/src/redux/slices/mainSlice.js
+++ b/src/redux/slices/mainSlice.js
@@ -33,7 +33,7 @@ const initialState = {
   applicationAlertMessage: 'System Error',
   applicationAlertSeverity: 'error',
   appConfig: null,
-  cartItems: [{ test: 'true' }],
+  cartItems: [],
   showCartModal: false
 }
 


### PR DESCRIPTION
**Related Issue(s):**

- NA

**Proposed Changes:**

1. Add cart button to search bar if config set to true
2. Add base of cart modal component

BONUS 1: fixed legend style bug - it now does not float high if no publish/launch/analyze buttons are present

BOUNS 2: refactor of responsiveness for mid and small size screens (first pass to resolve glaring issues, better refactor recommended for future ticket)

**Before BOUNS 2:**  
<img src="https://github.com/Element84/filmdrop-ui/assets/21375568/57504ec4-c8ef-467c-8c60-fdc86c300e56" width="500">

<img src="https://github.com/Element84/filmdrop-ui/assets/21375568/976113d6-113b-42c9-9435-c86b8caec0d0" width="500">

**After BOUNS 2:** 
<img src="https://github.com/Element84/filmdrop-ui/assets/21375568/2bc44dc1-0c8e-4fb5-8e45-86b5491dad49" width="500">

<img src="https://github.com/Element84/filmdrop-ui/assets/21375568/2b11199c-5cbe-4af3-aa99-2f7325505a43" width="500">


### To test:

all tests pass 🍏 `npm run test`

**Tests for Cart Button**

- set `CART_ENABLED` to `false` in `config.json`
- load app
- confirm cart button does not render
- stop app
- set `CART_ENABLED` to `true` in `config.json`
- load app
- confirm cart button renders in search bar
- confirm cart button reflects initial state of '0' items in cart
- confirm cart style is grey/disabled per mock
- click cart button
- confirm cart button click does not open cart modal
- stop app
- open `mainSlice.js` in editor (src/redux/slices/mainSlice.js)
- change `cartItems: []` on line 36 to be `cartItems: [{id: 'test'}]` to manually mock items in cart
- load app
- confirm cart button reflects cart state of '1' items in cart
- confirm cart style is no longer disabled and renders green per mock
- click cart button
- confirm cart button click opens cart modal
- click 'x' in top right of cart modal
- confirm cart modal closes

**Tests for Bonus 1**
- load app
- make sure `SHOW_PUBLISH_BTN` is true in `config.json` AND/OR `ANALYZE_BTN_URL` AND/OR `LAUNCH_URL` set
- search so results show on map
- confirm legend renders above publish button 
- stop app
- set `SHOW_PUBLISH_BTN` to false in `config.json`
- remove or set to null for both `ANALYZE_BTN_URL` AND `LAUNCH_URL` in `config.json`
- load app
- search so results show on map
- confirm legend renders lower in bottom left when publish, analyze or launch buttons not in app 

**PR Checklist:**

- [X] I have added my changes to the [CHANGELOG](https://github.com/Element84/filmdrop-ui/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
