### PR TITLE
Ba/feature/refactor popup results with cart options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Cart button added to search bar if `CART_ENABLED` set to true in `config.json` (WIP feature)
+- Cart button to `Add all to cart` & `Add/Remove scene from cart` added to search bar if `CART_ENABLED` set to true in `config.json` (WIP feature)
+- Cart buttons now show in PopupResults component if if `CART_ENABLED` set to true in `config.json` (WIP feature)
+- Cart items are now shown in layer on map if `CART_ENABLED` set to true in `config.json` and Items exist in cart. (WIP feature)
+
+### Changed
+
+- Map legend updated to always show 'Scenes in Cart' symbology when `CART_ENABLED` set to true in `config.json` and Items exist in cart. (WIP feature)
+- PopupResults component updated to allow users to minimize/maximize popup results component content.
 
 ## 3.2.0 - 2023-08-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Cart button to `Add all to cart` & `Add/Remove scene from cart` added to search bar if `CART_ENABLED` set to true in `config.json` (WIP feature)
-- Cart buttons now show in PopupResults component if if `CART_ENABLED` set to true in `config.json` (WIP feature)
 - Cart items are now shown in layer on map if `CART_ENABLED` set to true in `config.json` and Items exist in cart. (WIP feature)
 
 ### Changed

--- a/src/components/Layout/Content/BottomContent/BottomContent.jsx
+++ b/src/components/Layout/Content/BottomContent/BottomContent.jsx
@@ -37,6 +37,7 @@ const BottomContent = () => {
   const _searchGeojsonBoundary = useSelector(
     (state) => state.mainSlice.searchGeojsonBoundary
   )
+  const _cartItems = useSelector((state) => state.mainSlice.cartItems)
 
   const dispatch = useDispatch()
 
@@ -153,7 +154,9 @@ const BottomContent = () => {
           </div>
         </div>
       ) : null}
-      {_searchGeojsonBoundary || (_searchType && _searchResults) ? (
+      {_searchGeojsonBoundary ||
+      (_searchType && _searchResults) ||
+      _cartItems.length > 0 ? (
         <LayerLegend></LayerLegend>
       ) : null}
     </div>

--- a/src/components/Layout/Content/BottomContent/BottomContent.test.jsx
+++ b/src/components/Layout/Content/BottomContent/BottomContent.test.jsx
@@ -9,7 +9,8 @@ import {
   setisDrawingEnabled,
   setappConfig,
   setsearchGeojsonBoundary,
-  setSearchType
+  setSearchType,
+  setcartItems
 } from '../../../../redux/slices/mainSlice'
 import {
   mockSceneSearchResult,
@@ -69,6 +70,11 @@ describe('BottomContent', () => {
     it('should render Legend if searchType and searchResults set in redux', () => {
       store.dispatch(setSearchType('hex'))
       store.dispatch(setSearchResults({ type: 'Point', coordinates: [0, 0] }))
+      setup()
+      expect(screen.queryByTestId('testLayerLegend')).toBeInTheDocument()
+    })
+    it('should render Legend if cartItems has items set in redux', () => {
+      store.dispatch(setcartItems([mockSceneSearchResult]))
       setup()
       expect(screen.queryByTestId('testLayerLegend')).toBeInTheDocument()
     })

--- a/src/components/LeafMap/LeafMap.jsx
+++ b/src/components/LeafMap/LeafMap.jsx
@@ -17,10 +17,12 @@ import {
   mapCallDebounceNewSearch,
   setMosaicZoomMessage
 } from '../../utils/mapHelper'
+import { setScenesForCartLayer } from '../../utils/dataHelper'
 
 const LeafMap = () => {
   const dispatch = useDispatch()
   const _appConfig = useSelector((state) => state.mainSlice.appConfig)
+  const _cartItems = useSelector((state) => state.mainSlice.cartItems)
   // set map ref to itself with useRef
   const mapRef = useRef()
 
@@ -49,6 +51,10 @@ const LeafMap = () => {
       setLocalMap(mapRef.current)
     }
   }, [mapRef.current])
+
+  useEffect(() => {
+    setScenesForCartLayer()
+  }, [_cartItems])
 
   useEffect(() => {
     if (map && Object.keys(map).length) {
@@ -90,6 +96,18 @@ const LeafMap = () => {
       const resultFootprintsInit = new L.FeatureGroup()
       resultFootprintsInit.addTo(map)
       resultFootprintsInit.layer_name = 'searchResultsLayer'
+
+      const cartFootprintsInit = new L.FeatureGroup()
+      cartFootprintsInit.addTo(map)
+      cartFootprintsInit.layer_name = 'cartFootprintsLayer'
+      cartFootprintsInit.eachLayer(function (layer) {
+        layer.on('mouseover', function (e) {
+          map.getContainer().style.cursor = 'default'
+        })
+        layer.on('mouseout', function (e) {
+          map.getContainer().style.cursor = ''
+        })
+      })
 
       const clickedFootprintsHighlightInit = new L.FeatureGroup()
       clickedFootprintsHighlightInit.addTo(map)

--- a/src/components/Legend/LayerLegend/LayerLegend.jsx
+++ b/src/components/Legend/LayerLegend/LayerLegend.jsx
@@ -10,6 +10,7 @@ const LayerLegend = () => {
     (state) => state.mainSlice.searchGeojsonBoundary
   )
   const _searchResults = useSelector((state) => state.mainSlice.searchResults)
+  const _cartItems = useSelector((state) => state.mainSlice.cartItems)
   return (
     <div
       data-testid="testLayerLegend"
@@ -21,14 +22,14 @@ const LayerLegend = () => {
           : 'LayerLegend LayerLegendBottom'
       }
     >
+      {_appConfig.CART_ENABLED && _cartItems.length > 0 ? (
+        <div className="legendRow">
+          <div className="legendSymbol sceneInCartLegendSymbol"></div>
+          <span>Scenes in cart</span>
+        </div>
+      ) : null}
       {_searchType === 'scene' && (
         <div className="sceneLegend">
-          {_appConfig.CART_ENABLED ? (
-            <div className="legendRow">
-              <div className="legendSymbol sceneInCartLegendSymbol"></div>
-              <span>Scene in cart</span>
-            </div>
-          ) : null}
           <div className="legendRow">
             <div className="legendSymbol sceneLegendSymbol"></div>
             <span>Available scene</span>

--- a/src/components/Legend/LayerLegend/LayerLegend.test.jsx
+++ b/src/components/Legend/LayerLegend/LayerLegend.test.jsx
@@ -7,12 +7,14 @@ import {
   setSearchResults,
   setappConfig,
   setsearchGeojsonBoundary,
-  setSearchType
+  setSearchType,
+  setcartItems
 } from '../../../redux/slices/mainSlice'
 import {
   mockAppConfig,
   mockGridAggregateSearchResult,
-  mockHexAggregateSearchResult
+  mockHexAggregateSearchResult,
+  mockSceneSearchResult
 } from '../../../testing/shared-mocks'
 
 describe('LayerLegend', () => {
@@ -28,6 +30,31 @@ describe('LayerLegend', () => {
   })
 
   describe('on conditional render', () => {
+    describe('confirm conditional cart render', () => {
+      it('should render scenes in cart legend item if cart enabled in config and cart has items', () => {
+        const mockAppConfigSearchEnabled = {
+          ...mockAppConfig,
+          CART_ENABLED: 'true'
+        }
+        store.dispatch(setappConfig(mockAppConfigSearchEnabled))
+        store.dispatch(setcartItems([mockSceneSearchResult]))
+        setup()
+        expect(screen.queryByText(/scenes in cart/i)).toBeInTheDocument()
+      })
+      it('should not render scenes in cart legend item if cart enabled in config but cart has no items', () => {
+        const mockAppConfigSearchEnabled = {
+          ...mockAppConfig,
+          CART_ENABLED: 'true'
+        }
+        store.dispatch(setappConfig(mockAppConfigSearchEnabled))
+        setup()
+        expect(screen.queryByText(/scenes in cart/i)).not.toBeInTheDocument()
+      })
+      it('should not render scenes in cart legend item if cart not enabled in config', () => {
+        setup()
+        expect(screen.queryByText(/scenes in cart/i)).not.toBeInTheDocument()
+      })
+    })
     describe('confirm conditional scene render', () => {
       it('should render available scene legend item if searchType set to scene in redux', () => {
         store.dispatch(setSearchType('scene'))
@@ -38,21 +65,6 @@ describe('LayerLegend', () => {
         store.dispatch(setSearchType('grid-code'))
         setup()
         expect(screen.queryByText(/available scene/i)).not.toBeInTheDocument()
-      })
-      it('should render scene in cart legend item if searchType set to scene in redux and cart enabled in config', () => {
-        store.dispatch(setSearchType('scene'))
-        const mockAppConfigSearchEnabled = {
-          ...mockAppConfig,
-          CART_ENABLED: 'true'
-        }
-        store.dispatch(setappConfig(mockAppConfigSearchEnabled))
-        setup()
-        expect(screen.queryByText(/scene in cart/i)).toBeInTheDocument()
-      })
-      it('should not render scene in cart legend item if searchType set to scene in redux and cart not enabled in config', () => {
-        store.dispatch(setSearchType('scene'))
-        setup()
-        expect(screen.queryByText(/scene in cart/i)).not.toBeInTheDocument()
       })
     })
     describe('confirm conditional gird-code render', () => {

--- a/src/components/PopupResult/PopupResult.css
+++ b/src/components/PopupResult/PopupResult.css
@@ -4,8 +4,12 @@
   display: flex;
   flex-direction: column;
   background-color: #12171a;
-  border-bottom: #353d4f 3px solid;
-  margin-top: 35px;
+  margin-top: 10px;
+  padding-top: 10px;
+}
+
+.popupResultCartEnabled {
+  height: calc(100% - 90px);
 }
 
 .popupResultThumbnailContainer {
@@ -19,12 +23,6 @@
 .popupResultThumbnail {
   width: 325px;
   max-width: 100%;
-}
-
-.popupResultCaption {
-  padding: 20px;
-  display: inline-block;
-  font-size: 16px;
 }
 
 .popupResultDetails {
@@ -75,23 +73,4 @@
 /* Handle on hover */
 ::-webkit-scrollbar-thumb:hover {
   background: #555;
-}
-
-.closePopupModal {
-  position: absolute;
-  top: 5px;
-  right: 8px;
-  background-color: transparent;
-  color: #a9b0c1;
-  border: 0px;
-  font-size: 24px;
-  font-weight: bold;
-  height: 40px;
-  padding-left: 10px;
-  padding-right: 5px;
-  cursor: pointer;
-  transition: color 0.33s ease-in-out;
-  -webkit-touch-callout: none;
-  -webkit-user-select: none;
-  user-select: none;
 }

--- a/src/components/PopupResult/PopupResult.css
+++ b/src/components/PopupResult/PopupResult.css
@@ -41,12 +41,12 @@
   line-height: 1.6;
 }
 
-.detailRow label {
+.popupResultDetailsRowKey {
   font-weight: bold;
   color: #fff;
 }
 
-.detailRow span {
+.popupResultDetailsRowValue {
   font-size: 14px;
   word-wrap: break-word;
 }

--- a/src/components/PopupResult/PopupResult.jsx
+++ b/src/components/PopupResult/PopupResult.jsx
@@ -41,6 +41,7 @@ const PopupResult = (props) => {
 
   return (
     <div
+      data-testid="testPopupResult"
       className={
         _appConfig.CART_ENABLED
           ? 'popupResult popupResultCartEnabled'

--- a/src/components/PopupResult/PopupResult.jsx
+++ b/src/components/PopupResult/PopupResult.jsx
@@ -66,22 +66,22 @@ const PopupResult = (props) => {
           </div>
           <div className="popupResultDetails">
             <div className="detailRow">
-              <label>Title: </label>
+              <label htmlFor="title">Title: </label>
               <span>{props.result.id}</span>
             </div>
             <div className="detailRow">
-              <label>Collection Date: </label>
+              <label htmlFor="collectionDate">Collection Date: </label>
               <span>{props.result.properties.datetime}</span>
             </div>
             {cloudCover ? (
               <div className="detailRow">
-                <label>Cloud Cover: </label>
+                <label htmlFor="cloudCover">Cloud Cover: </label>
                 <span>{`${cloudCover?.toFixed(2)}%`}</span>
               </div>
             ) : null}
             {polarizations ? (
               <div className="detailRow">
-                <label>Polarizations: </label>
+                <label htmlFor="polarizations">Polarizations: </label>
                 <span>{`${polarizations}`}</span>
               </div>
             ) : null}

--- a/src/components/PopupResult/PopupResult.jsx
+++ b/src/components/PopupResult/PopupResult.jsx
@@ -67,17 +67,45 @@ const PopupResult = (props) => {
           </div>
           <div className="popupResultDetails">
             <div className="detailRow">
-              <label htmlFor="title">Title: </label>
-              <span>{props.result.id}</span>
+              <span
+                className="popupResultDetailsRowKey"
+                id="popupResultDetailsTitle"
+              >
+                Title:
+              </span>
+              <span
+                className="popupResultDetailsRowValue"
+                aria-labelledby="popupResultDetailsTitle"
+              >
+                {props.result.id}
+              </span>
             </div>
             <div className="detailRow">
-              <label htmlFor="collectionDate">Collection Date: </label>
-              <span>{props.result.properties.datetime}</span>
+              <span
+                className="popupResultDetailsRowKey"
+                id="popupResultDetailsCollectionDate"
+              >
+                Collection Date:{' '}
+              </span>
+              <span
+                className="popupResultDetailsRowValue"
+                aria-labelledby="popupResultDetailsCollectionDate"
+              >
+                {props.result.properties.datetime}
+              </span>
             </div>
             {cloudCover ? (
               <div className="detailRow">
-                <label htmlFor="cloudCover">Cloud Cover: </label>
-                <span>{`${cloudCover?.toFixed(2)}%`}</span>
+                <span
+                  className="popupResultDetailsRowKey"
+                  id="popupResultDetailsCloudCover"
+                >
+                  Cloud Cover:{' '}
+                </span>
+                <span
+                  className="popupResultDetailsRowValue"
+                  aria-labelledby="popupResultDetailsCloudCover"
+                >{`${cloudCover?.toFixed(2)}%`}</span>
               </div>
             ) : null}
             {polarizations ? (

--- a/src/components/PopupResult/PopupResult.jsx
+++ b/src/components/PopupResult/PopupResult.jsx
@@ -1,28 +1,16 @@
 import { React, useEffect, useState } from 'react'
 import PropTypes from 'prop-types'
 import './PopupResult.css'
-
-import { useDispatch } from 'react-redux'
-import {
-  setCurrentPopupResult,
-  setShowPopupModal
-} from '../../redux/slices/mainSlice'
-
-import {
-  clearMapSelection,
-  debounceTitilerOverlay
-} from '../../utils/mapHelper'
+import { useDispatch, useSelector } from 'react-redux'
+import { setCurrentPopupResult } from '../../redux/slices/mainSlice'
 
 const PopupResult = (props) => {
   const dispatch = useDispatch()
+  const _appConfig = useSelector((state) => state.mainSlice.appConfig)
   const [thumbnailURL, setthumbnailURL] = useState(null)
 
   useEffect(() => {
     if (props.result) {
-      dispatch(setCurrentPopupResult(props.result))
-
-      debounceTitilerOverlay()
-
       const thumbnailURLForSelection = props.result?.links?.find(
         ({ rel }) => rel === 'thumbnail'
       )?.href
@@ -51,13 +39,14 @@ const PopupResult = (props) => {
   const cloudCover = props.result?.properties['eo:cloud_cover']
   const polarizations = props.result?.properties['sar:polarizations']
 
-  function onCloseClick() {
-    clearMapSelection()
-    dispatch(setShowPopupModal(false))
-  }
-
   return (
-    <div className="popupResult">
+    <div
+      className={
+        _appConfig.CART_ENABLED
+          ? 'popupResult popupResultCartEnabled'
+          : 'popupResult'
+      }
+    >
       {props.result ? (
         <div>
           <div className="popupResultThumbnailContainer">
@@ -97,9 +86,6 @@ const PopupResult = (props) => {
               </div>
             ) : null}
           </div>
-          <button className="closePopupModal" onClick={() => onCloseClick()}>
-            ✕
-          </button>
         </div>
       ) : null}
     </div>

--- a/src/components/PopupResults/PopupResults.css
+++ b/src/components/PopupResults/PopupResults.css
@@ -1,9 +1,9 @@
 .popupResultsContainer {
-  height: calc(100% - 60px);
+  height: calc(100% - 80px);
   width: 400px;
   position: absolute;
   z-index: 2;
-  bottom: 30px;
+  bottom: 40px;
   right: 10px;
   display: flex;
   flex-direction: column;
@@ -14,32 +14,198 @@
   z-index: 5;
 }
 
+.popupResultsContainerMin {
+  height: unset;
+}
+
 .popupResults {
   height: 100%;
   display: flex;
   flex-direction: column;
 }
 
-.popupFooter {
-  height: 30px;
-  font-size: 18px;
+.popupHeader {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding-bottom: 5px;
+  border-bottom: #353d4f 3px solid;
+}
+
+.popupHeaderTop {
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+}
+
+.popupHeaderBottom {
   display: flex;
   flex-direction: row;
   justify-content: center;
+  height: 32px;
+  width: 100%;
+  margin-top: 5px;
+  margin-bottom: 10px;
+}
+
+.popupHeaderBottomButton {
+  background-color: transparent;
+  color: #a9b0c1;
+  border: 1px solid #a9b0c1;
+  border-radius: 5px;
+  height: 32px;
+  font-size: 16px;
+  width: 80%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: color 0.33s ease-in-out;
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  user-select: none;
+}
+.popupHeaderBottomButton:hover {
+  background-color: #252f36;
+  color: #fff;
+}
+.popupHeaderBottomButtonDisabled {
+  color: #646566;
+  border: 1px solid #646566;
+  cursor: default;
+}
+.popupHeaderBottomButtonDisabled:hover {
+  background-color: transparent;
+  color: #646566;
+}
+
+.popupResultsBottom {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  height: 32px;
+  width: 100%;
+  margin-top: 20px;
+  margin-bottom: 20px;
+}
+
+.popupResultsBottomButton {
+  background-color: transparent;
+  color: #a9b0c1;
+  border: 1px solid #a9b0c1;
+  border-radius: 5px;
+  height: 32px;
+  font-size: 16px;
+  width: 80%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: color 0.33s ease-in-out;
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  user-select: none;
+}
+.popupResultsBottomButton:hover {
+  background-color: #252f36;
+  color: #fff;
+}
+
+.popupHeaderButtonsGroup {
+  display: flex;
+  flex-direction: row;
+}
+
+.popupHeaderButtons {
+  background-color: transparent;
+  color: #a9b0c1;
+  border: 0px;
+  font-weight: bold;
+  height: 30px;
+  width: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: color 0.33s ease-in-out;
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.popupResultsContent {
+  height: calc(100% - 91px);
+  border-bottom: #353d4f 3px solid;
+}
+
+.popupResultsContentCartEnabled {
+  height: calc(100% - 138px);
+}
+
+.popupResultContentText {
+  height: 40px;
+  font-size: 16px;
+  display: flex;
+  align-items: center;
+  padding-left: 10px;
+}
+
+.popupFooter {
+  font-size: 18px;
+  display: flex;
+  flex-direction: row;
   align-items: center;
   margin-top: 10px;
 }
 
-.popupFooterIconContainer {
+.popupFooterControls {
+  width: 100%;
   display: flex;
-  justify-content: center;
   align-items: center;
-  padding-left: 10px;
-  padding-right: 10px;
+  justify-content: space-between;
 }
 
-.popupFooterIcon {
-  color: #dedede;
-  transform: scale(1.2);
+.popupFooterControlLeft {
+  padding-left: 10px;
+}
+
+.popupFooterButtonsGroup {
+  display: flex;
+  flex-direction: row;
+}
+
+.popupFooterButton {
+  background-color: transparent;
+  color: #a9b0c1;
+  border: 0px;
+  font-weight: bold;
+  height: 30px;
+  width: 30px;
+  border: #dedede solid 1px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   cursor: pointer;
+  transition: color 0.33s ease-in-out;
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.popupFooterButton:hover {
+  background-color: #252f36;
+  color: #fff;
+}
+
+.popupFooterButtonRight {
+  margin-left: -1px;
+  border-top-right-radius: 5px;
+  border-bottom-right-radius: 5px;
+}
+
+.popupFooterButtonLeft {
+  margin-left: -1px;
+  border-top-left-radius: 5px;
+  border-bottom-left-radius: 5px;
 }

--- a/src/components/PopupResults/PopupResults.jsx
+++ b/src/components/PopupResults/PopupResults.jsx
@@ -1,17 +1,46 @@
 import { React, useEffect, useState } from 'react'
 import PropTypes from 'prop-types'
 import './PopupResults.css'
-
+import { useDispatch, useSelector } from 'react-redux'
 import PopupResult from '../PopupResult/PopupResult'
-
+import {
+  clearMapSelection,
+  debounceTitilerOverlay
+} from '../../utils/mapHelper'
+import {
+  setShowPopupModal,
+  setCurrentPopupResult,
+  setcartItems,
+  setSearchLoading
+} from '../../redux/slices/mainSlice'
 import { ChevronRight, ChevronLeft } from '@mui/icons-material'
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown'
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp'
+import CloseIcon from '@mui/icons-material/Close'
+import {
+  isSceneInCart,
+  numberOfSelectedInCart,
+  areAllScenesSelectedInCart
+} from '../../utils/dataHelper'
 
 const PopupResults = (props) => {
+  const dispatch = useDispatch()
+  const _cartItems = useSelector((state) => state.mainSlice.cartItems)
+  const _appConfig = useSelector((state) => state.mainSlice.appConfig)
   const [currentResultIndex, setCurrentResultIndex] = useState(0)
+  const [minimizePopup, setminimizePopup] = useState(false)
 
   useEffect(() => {
     setCurrentResultIndex(0)
   }, [props.results])
+
+  useEffect(() => {
+    dispatch(setCurrentPopupResult(props.results[currentResultIndex]))
+    debounceTitilerOverlay()
+    return () => {
+      dispatch(setSearchLoading(false))
+    }
+  }, [currentResultIndex, props.results])
 
   function onNextClick() {
     if (currentResultIndex < props.results.length - 1) {
@@ -25,24 +54,154 @@ const PopupResults = (props) => {
     }
   }
 
+  function onMinimizeClicked() {
+    setminimizePopup(!minimizePopup)
+  }
+
+  function onCloseClick() {
+    clearMapSelection()
+    dispatch(setSearchLoading(false))
+    dispatch(setShowPopupModal(false))
+  }
+
+  function onAddRemoveSceneToCartClicked() {
+    if (isSceneInCart(props.results[currentResultIndex])) {
+      dispatch(
+        setcartItems(
+          _cartItems.filter(
+            (_cartItems) =>
+              _cartItems.id !== props.results[currentResultIndex].id
+          )
+        )
+      )
+      return
+    }
+    dispatch(setcartItems([..._cartItems, props.results[currentResultIndex]]))
+  }
+
+  function onAddAllToCartClicked() {
+    if (areAllScenesSelectedInCart(props.results)) {
+      return
+    }
+    const cartPlusNewScenes = [..._cartItems]
+    props.results.forEach((result) => {
+      const sceneInCart = isSceneInCart(result)
+      if (!sceneInCart) {
+        cartPlusNewScenes.push(result)
+      }
+    })
+    dispatch(setcartItems(cartPlusNewScenes))
+  }
+
   return (
-    <div className="popupResultsContainer">
+    <div
+      className={
+        minimizePopup
+          ? 'popupResultsContainer popupResultsContainerMin'
+          : 'popupResultsContainer'
+      }
+    >
       {props.results ? (
         <div className="popupResults">
-          <PopupResult result={props.results[currentResultIndex]}></PopupResult>
-          <div className="popupFooter">
-            <div className="popupFooterPrev popupFooterIconContainer">
-              <ChevronLeft
-                className="popupFooterIcon"
-                onClick={() => onPrevClick()}
-              ></ChevronLeft>
+          <div className="popupHeader">
+            <div className="popupHeaderTop">
+              <div className="popupResultContentText">
+                {props.results.length + ' scenes selected'}{' '}
+                {/* TODO: replace _cartItems.length with function that returns count of selected results */}
+                {_appConfig.CART_ENABLED &&
+                numberOfSelectedInCart(props.results) > 0
+                  ? '(' + numberOfSelectedInCart(props.results) + ' in cart)'
+                  : null}
+              </div>
+              <div className="popupHeaderButtonsGroup">
+                <button
+                  className="popupHeaderButtons"
+                  onClick={onMinimizeClicked}
+                >
+                  {minimizePopup ? (
+                    <KeyboardArrowUpIcon
+                      sx={{ fontSize: 27, color: '#a9b0c1' }}
+                    ></KeyboardArrowUpIcon>
+                  ) : (
+                    <KeyboardArrowDownIcon
+                      sx={{ fontSize: 27, color: '#a9b0c1' }}
+                    ></KeyboardArrowDownIcon>
+                  )}
+                </button>
+                <button
+                  className="popupHeaderButtons"
+                  onClick={() => onCloseClick()}
+                >
+                  <CloseIcon
+                    sx={{ fontSize: 20, color: '#a9b0c1' }}
+                  ></CloseIcon>
+                </button>
+              </div>
             </div>
-            {currentResultIndex + 1 + ' of ' + props.results.length}
-            <div className="popupFooterNext popupFooterIconContainer">
-              <ChevronRight
-                className="popupFooterIcon"
-                onClick={() => onNextClick()}
-              ></ChevronRight>
+            {_appConfig.CART_ENABLED ? (
+              <div className="popupHeaderBottom">
+                <button
+                  className={
+                    areAllScenesSelectedInCart(props.results)
+                      ? 'popupHeaderBottomButton popupHeaderBottomButtonDisabled'
+                      : 'popupHeaderBottomButton'
+                  }
+                  onClick={onAddAllToCartClicked}
+                >
+                  Add all to cart
+                </button>
+              </div>
+            ) : null}
+          </div>
+
+          {minimizePopup ? null : (
+            <div
+              className={
+                _appConfig.CART_ENABLED
+                  ? 'popupResultsContent popupResultsContentCartEnabled'
+                  : 'popupResultsContent'
+              }
+            >
+              <PopupResult
+                result={props.results[currentResultIndex]}
+              ></PopupResult>
+              {_appConfig.CART_ENABLED ? (
+                <div className="popupResultsBottom">
+                  <button
+                    className="popupResultsBottomButton"
+                    onClick={onAddRemoveSceneToCartClicked}
+                  >
+                    {isSceneInCart(props.results[currentResultIndex])
+                      ? 'Remove scene from cart'
+                      : 'Add scene to cart'}
+                  </button>
+                </div>
+              ) : null}
+            </div>
+          )}
+          <div className="popupFooter">
+            <div className="popupFooterControls">
+              <div className="popupFooterControlLeft">
+                {currentResultIndex + 1 + ' of ' + props.results.length}
+              </div>
+              <div className="popupFooterButtonsGroup">
+                <div className="popupFooterPrev popupFooterIconContainer">
+                  <button
+                    onClick={() => onPrevClick()}
+                    className="popupFooterButton popupFooterButtonLeft"
+                  >
+                    <ChevronLeft></ChevronLeft>
+                  </button>
+                </div>
+                <div className="popupFooterNext popupFooterIconContainer ">
+                  <button
+                    className="popupFooterButton popupFooterButtonRight"
+                    onClick={() => onNextClick()}
+                  >
+                    <ChevronRight></ChevronRight>
+                  </button>
+                </div>
+              </div>
             </div>
           </div>
         </div>

--- a/src/components/PopupResults/PopupResults.jsx
+++ b/src/components/PopupResults/PopupResults.jsx
@@ -95,6 +95,7 @@ const PopupResults = (props) => {
 
   return (
     <div
+      data-testid="testPopupResults"
       className={
         minimizePopup
           ? 'popupResultsContainer popupResultsContainerMin'
@@ -107,7 +108,6 @@ const PopupResults = (props) => {
             <div className="popupHeaderTop">
               <div className="popupResultContentText">
                 {props.results.length + ' scenes selected'}{' '}
-                {/* TODO: replace _cartItems.length with function that returns count of selected results */}
                 {_appConfig.CART_ENABLED &&
                 numberOfSelectedInCart(props.results) > 0
                   ? '(' + numberOfSelectedInCart(props.results) + ' in cart)'

--- a/src/components/PopupResults/PopupResults.test.jsx
+++ b/src/components/PopupResults/PopupResults.test.jsx
@@ -1,0 +1,238 @@
+import React from 'react'
+
+import { render, screen, fireEvent, within } from '@testing-library/react'
+import PopupResults from './PopupResults'
+import { Provider } from 'react-redux'
+import { store } from '../../redux/store'
+import {
+  setShowPopupModal,
+  setappConfig,
+  setcartItems
+} from '../../redux/slices/mainSlice'
+import { mockAppConfig, mockClickResults } from '../../testing/shared-mocks'
+import { describe } from 'vitest'
+
+describe('PopupResult', () => {
+  const setup = () =>
+    render(
+      <Provider store={store}>
+        <PopupResults results={mockClickResults} />
+      </Provider>
+    )
+
+  beforeEach(() => {
+    store.dispatch(setappConfig(mockAppConfig))
+  })
+
+  describe('on conditional render', () => {
+    describe('cart buttons', () => {
+      it('should render cart count in popup header if cart enabled in config and cart has items', () => {
+        const mockAppConfigSearchEnabled = {
+          ...mockAppConfig,
+          CART_ENABLED: 'true'
+        }
+        store.dispatch(setappConfig(mockAppConfigSearchEnabled))
+        store.dispatch(setcartItems([mockClickResults[0]]))
+        setup()
+        expect(
+          screen.queryByText(/2 scenes selected \(1 in cart\)/i)
+        ).toBeInTheDocument()
+      })
+      it('should render add all to cart button in popup header if cart enabled in config', () => {
+        const mockAppConfigSearchEnabled = {
+          ...mockAppConfig,
+          CART_ENABLED: 'true'
+        }
+        store.dispatch(setappConfig(mockAppConfigSearchEnabled))
+        store.dispatch(setcartItems([mockClickResults[0]]))
+        setup()
+        expect(
+          screen.queryByRole('button', {
+            name: /add all to cart/i
+          })
+        ).toBeInTheDocument()
+      })
+      it('should render add all to cart button in popup footer if cart enabled in config', () => {
+        const mockAppConfigSearchEnabled = {
+          ...mockAppConfig,
+          CART_ENABLED: 'true'
+        }
+        store.dispatch(setappConfig(mockAppConfigSearchEnabled))
+        setup()
+        expect(
+          screen.queryByRole('button', {
+            name: /add scene to cart/i
+          })
+        ).toBeInTheDocument()
+      })
+      it('should not render cart count in popup header if cart not enabled in config', () => {
+        store.dispatch(setappConfig(mockAppConfig))
+        setup()
+        expect(screen.queryByText(/2 scenes selected/i)).toBeInTheDocument()
+        expect(
+          screen.queryByText(/2 scenes selected \(1 in cart\)/i)
+        ).not.toBeInTheDocument()
+      })
+      it('should not render add all to cart button in popup header if cart not enabled in config', () => {
+        store.dispatch(setappConfig(mockAppConfig))
+        store.dispatch(setcartItems([mockClickResults[0]]))
+        setup()
+        expect(
+          screen.queryByRole('button', {
+            name: /add all to cart/i
+          })
+        ).not.toBeInTheDocument()
+      })
+      it('should not render add all to cart button in popup footer if cart not enabled in config', () => {
+        store.dispatch(setappConfig(mockAppConfig))
+        store.dispatch(setcartItems([mockClickResults[0]]))
+        setup()
+        expect(
+          screen.queryByRole('button', {
+            name: /add scene to cart/i
+          })
+        ).not.toBeInTheDocument()
+      })
+      it('should render text as remove from cart in popup footer if scene already in cart', () => {
+        const mockAppConfigSearchEnabled = {
+          ...mockAppConfig,
+          CART_ENABLED: 'true'
+        }
+        store.dispatch(setappConfig(mockAppConfigSearchEnabled))
+        store.dispatch(setcartItems([mockClickResults[0]]))
+        setup()
+        expect(
+          screen.queryByRole('button', {
+            name: /remove scene from cart/i
+          })
+        ).toBeInTheDocument()
+      })
+    })
+    describe('minimized popupResult', () => {
+      it('should not render minimized popupResult on down arrow clicked', () => {
+        store.dispatch(setappConfig(mockAppConfig))
+        setup()
+        expect(screen.queryByTestId('testPopupResult')).toBeInTheDocument()
+        const view = within(screen.getByTestId('testPopupResults')).getByTestId(
+          'KeyboardArrowDownIcon'
+        )
+        fireEvent.click(view)
+        expect(screen.queryByTestId('testPopupResult')).not.toBeInTheDocument()
+      })
+      it('should not render minimized add scene to cart button on down arrow clicked if cart enabled in config', () => {
+        const mockAppConfigSearchEnabled = {
+          ...mockAppConfig,
+          CART_ENABLED: 'true'
+        }
+        store.dispatch(setappConfig(mockAppConfigSearchEnabled))
+        setup()
+        expect(
+          screen.queryByRole('button', {
+            name: /add scene to cart/i
+          })
+        ).toBeInTheDocument()
+        const view = within(screen.getByTestId('testPopupResults')).getByTestId(
+          'KeyboardArrowDownIcon'
+        )
+        fireEvent.click(view)
+        expect(
+          screen.queryByRole('button', {
+            name: /add scene to cart/i
+          })
+        ).not.toBeInTheDocument()
+      })
+    })
+  })
+  describe('on button clicks', () => {
+    describe('on close button clicked', () => {
+      it('should set showPopupModal in redux to be false', () => {
+        store.dispatch(setappConfig(mockAppConfig))
+        store.dispatch(setShowPopupModal(true))
+        setup()
+        expect(store.getState().mainSlice.showPopupModal).toBeTruthy()
+        fireEvent.click(screen.getByTestId('CloseIcon'))
+        expect(store.getState().mainSlice.showPopupModal).toBeFalsy()
+      })
+    })
+    describe('on Add all to cart button clicked', () => {
+      it('should add all items to cart if none currently in cart', () => {
+        const mockAppConfigSearchEnabled = {
+          ...mockAppConfig,
+          CART_ENABLED: 'true'
+        }
+        store.dispatch(setappConfig(mockAppConfigSearchEnabled))
+        setup()
+        expect(store.getState().mainSlice.cartItems.length).toBe(0)
+        fireEvent.click(
+          screen.getByRole('button', { name: /add all to cart/i })
+        )
+        expect(store.getState().mainSlice.cartItems.length).toBe(
+          mockClickResults.length
+        )
+      })
+      it('should only add items to cart that are not already in cart', () => {
+        const mockAppConfigSearchEnabled = {
+          ...mockAppConfig,
+          CART_ENABLED: 'true'
+        }
+        store.dispatch(setappConfig(mockAppConfigSearchEnabled))
+        store.dispatch(setcartItems([mockClickResults[0]]))
+        setup()
+        expect(store.getState().mainSlice.cartItems.length).toBe(1)
+        fireEvent.click(
+          screen.getByRole('button', { name: /add all to cart/i })
+        )
+        expect(store.getState().mainSlice.cartItems.length).toBe(
+          mockClickResults.length
+        )
+      })
+      it('should not add any items if all items are already in cart', () => {
+        const mockAppConfigSearchEnabled = {
+          ...mockAppConfig,
+          CART_ENABLED: 'true'
+        }
+        store.dispatch(setappConfig(mockAppConfigSearchEnabled))
+        store.dispatch(setcartItems(mockClickResults))
+        setup()
+        expect(store.getState().mainSlice.cartItems.length).toBe(
+          mockClickResults.length
+        )
+        fireEvent.click(
+          screen.getByRole('button', { name: /add all to cart/i })
+        )
+        expect(store.getState().mainSlice.cartItems.length).toBe(
+          mockClickResults.length
+        )
+      })
+    })
+    describe('on Add scene to cart button clicked', () => {
+      it('should add clicked scene to cart if scene not in cart', () => {
+        const mockAppConfigSearchEnabled = {
+          ...mockAppConfig,
+          CART_ENABLED: 'true'
+        }
+        store.dispatch(setappConfig(mockAppConfigSearchEnabled))
+        setup()
+        expect(store.getState().mainSlice.cartItems.length).toBe(0)
+        fireEvent.click(
+          screen.getByRole('button', { name: /add scene to cart/i })
+        )
+        expect(store.getState().mainSlice.cartItems.length).toBe(1)
+      })
+      it('should remove clicked scene from cart if scene in cart', () => {
+        const mockAppConfigSearchEnabled = {
+          ...mockAppConfig,
+          CART_ENABLED: 'true'
+        }
+        store.dispatch(setappConfig(mockAppConfigSearchEnabled))
+        store.dispatch(setcartItems([mockClickResults[0]]))
+        setup()
+        expect(store.getState().mainSlice.cartItems.length).toBe(1)
+        fireEvent.click(
+          screen.getByRole('button', { name: /remove scene from cart/i })
+        )
+        expect(store.getState().mainSlice.cartItems.length).toBe(0)
+      })
+    })
+  })
+})

--- a/src/components/PopupResults/PopupResults.test.jsx
+++ b/src/components/PopupResults/PopupResults.test.jsx
@@ -1,5 +1,4 @@
 import React from 'react'
-
 import { render, screen, fireEvent, within } from '@testing-library/react'
 import PopupResults from './PopupResults'
 import { Provider } from 'react-redux'

--- a/src/components/PopupResults/PopupResults.test.jsx
+++ b/src/components/PopupResults/PopupResults.test.jsx
@@ -234,5 +234,30 @@ describe('PopupResult', () => {
         expect(store.getState().mainSlice.cartItems.length).toBe(0)
       })
     })
+    describe('on prev & next scene buttons clicked', () => {
+      it('should set scene result in redux to next and prev scene if not out of range', () => {
+        store.dispatch(setappConfig(mockAppConfig))
+        setup()
+        expect(store.getState().mainSlice.currentPopupResult).toEqual(
+          mockClickResults[0]
+        )
+        fireEvent.click(screen.getByTestId('ChevronRightIcon'))
+        expect(store.getState().mainSlice.currentPopupResult).toEqual(
+          mockClickResults[1]
+        )
+        fireEvent.click(screen.getByTestId('ChevronRightIcon'))
+        expect(store.getState().mainSlice.currentPopupResult).toEqual(
+          mockClickResults[1]
+        )
+        fireEvent.click(screen.getByTestId('ChevronLeftIcon'))
+        expect(store.getState().mainSlice.currentPopupResult).toEqual(
+          mockClickResults[0]
+        )
+        fireEvent.click(screen.getByTestId('ChevronLeftIcon'))
+        expect(store.getState().mainSlice.currentPopupResult).toEqual(
+          mockClickResults[0]
+        )
+      })
+    })
   })
 })

--- a/src/testing/shared-mocks.js
+++ b/src/testing/shared-mocks.js
@@ -3549,3 +3549,1963 @@ export const mockAppConfig = {
   CART_ENABLED: false,
   SHOW_BRAND_LOGO: true
 }
+
+export const mockClickResults = [
+  {
+    type: 'Feature',
+    stac_version: '1.0.0',
+    id: 'S2B_17SNB_20230801_0_L2A',
+    properties: {
+      created: '2023-08-02T01:04:42.598Z',
+      platform: 'sentinel-2b',
+      constellation: 'sentinel-2',
+      instruments: ['msi'],
+      'eo:cloud_cover': 10.123754,
+      'proj:epsg': 32617,
+      'mgrs:utm_zone': 17,
+      'mgrs:latitude_band': 'S',
+      'mgrs:grid_square': 'NB',
+      'grid:code': 'MGRS-17SNB',
+      'view:sun_azimuth': 134.826629308296,
+      'view:sun_elevation': 64.5308565780359,
+      's2:degraded_msi_data_percentage': 0.0169,
+      's2:nodata_pixel_percentage': 13.382663,
+      's2:saturated_defective_pixel_percentage': 0,
+      's2:dark_features_percentage': 0.050508,
+      's2:cloud_shadow_percentage': 5.57465,
+      's2:vegetation_percentage': 80.913961,
+      's2:not_vegetated_percentage': 2.433447,
+      's2:water_percentage': 0.225683,
+      's2:unclassified_percentage': 0.677995,
+      's2:medium_proba_clouds_percentage': 5.293403,
+      's2:high_proba_clouds_percentage': 4.423752,
+      's2:thin_cirrus_percentage': 0.406599,
+      's2:snow_ice_percentage': 0,
+      's2:product_type': 'S2MSI2A',
+      's2:processing_baseline': '05.09',
+      's2:product_uri':
+        'S2B_MSIL2A_20230801T155829_N0509_R097_T17SNB_20230801T204743.SAFE',
+      's2:generation_time': '2023-08-01T20:47:43.000000Z',
+      's2:datatake_id': 'GS2B_20230801T155829_033442_N05.09',
+      's2:datatake_type': 'INS-NOBS',
+      's2:datastrip_id':
+        'S2B_OPER_MSI_L2A_DS_2BPS_20230801T204743_S20230801T160859_N05.09',
+      's2:granule_id':
+        'S2B_OPER_MSI_L2A_TL_2BPS_20230801T204743_A033442_T17SNB_N05.09',
+      's2:reflectance_conversion_factor': 0.969933433227093,
+      datetime: '2023-08-01T16:13:05.549000Z',
+      's2:sequence': '0',
+      'earthsearch:s3_path':
+        's3://sentinel-cogs/sentinel-s2-l2a-cogs/17/S/NB/2023/8/S2B_17SNB_20230801_0_L2A',
+      'earthsearch:payload_id':
+        'roda-sentinel2/workflow-sentinel2-to-stac/c5043c5c3483ccca0c3fcc1c987cdfc8',
+      'earthsearch:boa_offset_applied': true,
+      'processing:software': {
+        'sentinel2-to-stac': '0.1.1'
+      },
+      updated: '2023-08-02T01:04:42.598Z'
+    },
+    geometry: {
+      type: 'Polygon',
+      coordinates: [
+        [
+          [-80.69049497570961, 37.947173482649525],
+          [-80.74711573388302, 37.747386931802936],
+          [-80.85420953215277, 37.37961342804283],
+          [-80.88508924806412, 37.26600499133067],
+          [-80.9740087373394, 36.957887265054474],
+          [-79.76700583572914, 36.951488600423914],
+          [-79.75065723902863, 37.94094734012891],
+          [-80.69049497570961, 37.947173482649525]
+        ]
+      ]
+    },
+    links: [
+      {
+        rel: 'self',
+        type: 'application/geo+json',
+        href: 'https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/items/S2B_17SNB_20230801_0_L2A'
+      },
+      {
+        rel: 'canonical',
+        href: 's3://sentinel-cogs/sentinel-s2-l2a-cogs/17/S/NB/2023/8/S2B_17SNB_20230801_0_L2A/S2B_17SNB_20230801_0_L2A.json',
+        type: 'application/json'
+      },
+      {
+        rel: 'license',
+        href: 'https://sentinel.esa.int/documents/247904/690755/Sentinel_Data_Legal_Notice'
+      },
+      {
+        rel: 'derived_from',
+        href: 'https://earth-search.aws.element84.com/v1/collections/sentinel-2-l1c/items/S2B_17SNB_20230801_0_L1C',
+        type: 'application/geo+json'
+      },
+      {
+        rel: 'parent',
+        type: 'application/json',
+        href: 'https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a'
+      },
+      {
+        rel: 'collection',
+        type: 'application/json',
+        href: 'https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a'
+      },
+      {
+        rel: 'root',
+        type: 'application/json',
+        href: 'https://earth-search.aws.element84.com/v1'
+      },
+      {
+        rel: 'thumbnail',
+        href: 'https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/items/S2B_17SNB_20230801_0_L2A/thumbnail'
+      }
+    ],
+    assets: {
+      aot: {
+        href: 'https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/17/S/NB/2023/8/S2B_17SNB_20230801_0_L2A/AOT.tif',
+        type: 'image/tiff; application=geotiff; profile=cloud-optimized',
+        title: 'Aerosol optical thickness (AOT)',
+        'proj:shape': [5490, 5490],
+        'proj:transform': [20, 0, 499980, 0, -20, 4200000],
+        'raster:bands': [
+          {
+            nodata: 0,
+            data_type: 'uint16',
+            bits_per_sample: 15,
+            spatial_resolution: 20,
+            scale: 0.001,
+            offset: 0
+          }
+        ],
+        roles: ['data', 'reflectance']
+      },
+      blue: {
+        href: 'https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/17/S/NB/2023/8/S2B_17SNB_20230801_0_L2A/B02.tif',
+        type: 'image/tiff; application=geotiff; profile=cloud-optimized',
+        title: 'Blue (band 2) - 10m',
+        'eo:bands': [
+          {
+            name: 'blue',
+            common_name: 'blue',
+            description: 'Blue (band 2)',
+            center_wavelength: 0.49,
+            full_width_half_max: 0.098
+          }
+        ],
+        gsd: 10,
+        'proj:shape': [10980, 10980],
+        'proj:transform': [10, 0, 499980, 0, -10, 4200000],
+        'raster:bands': [
+          {
+            nodata: 0,
+            data_type: 'uint16',
+            bits_per_sample: 15,
+            spatial_resolution: 10,
+            scale: 0.0001,
+            offset: -0.1
+          }
+        ],
+        roles: ['data', 'reflectance']
+      },
+      coastal: {
+        href: 'https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/17/S/NB/2023/8/S2B_17SNB_20230801_0_L2A/B01.tif',
+        type: 'image/tiff; application=geotiff; profile=cloud-optimized',
+        title: 'Coastal aerosol (band 1) - 60m',
+        'eo:bands': [
+          {
+            name: 'coastal',
+            common_name: 'coastal',
+            description: 'Coastal aerosol (band 1)',
+            center_wavelength: 0.443,
+            full_width_half_max: 0.027
+          }
+        ],
+        gsd: 60,
+        'proj:shape': [1830, 1830],
+        'proj:transform': [60, 0, 499980, 0, -60, 4200000],
+        'raster:bands': [
+          {
+            nodata: 0,
+            data_type: 'uint16',
+            bits_per_sample: 15,
+            spatial_resolution: 60,
+            scale: 0.0001,
+            offset: -0.1
+          }
+        ],
+        roles: ['data', 'reflectance']
+      },
+      granule_metadata: {
+        href: 'https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/17/S/NB/2023/8/S2B_17SNB_20230801_0_L2A/granule_metadata.xml',
+        type: 'application/xml',
+        roles: ['metadata']
+      },
+      green: {
+        href: 'https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/17/S/NB/2023/8/S2B_17SNB_20230801_0_L2A/B03.tif',
+        type: 'image/tiff; application=geotiff; profile=cloud-optimized',
+        title: 'Green (band 3) - 10m',
+        'eo:bands': [
+          {
+            name: 'green',
+            common_name: 'green',
+            description: 'Green (band 3)',
+            center_wavelength: 0.56,
+            full_width_half_max: 0.045
+          }
+        ],
+        gsd: 10,
+        'proj:shape': [10980, 10980],
+        'proj:transform': [10, 0, 499980, 0, -10, 4200000],
+        'raster:bands': [
+          {
+            nodata: 0,
+            data_type: 'uint16',
+            bits_per_sample: 15,
+            spatial_resolution: 10,
+            scale: 0.0001,
+            offset: -0.1
+          }
+        ],
+        roles: ['data', 'reflectance']
+      },
+      nir: {
+        href: 'https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/17/S/NB/2023/8/S2B_17SNB_20230801_0_L2A/B08.tif',
+        type: 'image/tiff; application=geotiff; profile=cloud-optimized',
+        title: 'NIR 1 (band 8) - 10m',
+        'eo:bands': [
+          {
+            name: 'nir',
+            common_name: 'nir',
+            description: 'NIR 1 (band 8)',
+            center_wavelength: 0.842,
+            full_width_half_max: 0.145
+          }
+        ],
+        gsd: 10,
+        'proj:shape': [10980, 10980],
+        'proj:transform': [10, 0, 499980, 0, -10, 4200000],
+        'raster:bands': [
+          {
+            nodata: 0,
+            data_type: 'uint16',
+            bits_per_sample: 15,
+            spatial_resolution: 10,
+            scale: 0.0001,
+            offset: -0.1
+          }
+        ],
+        roles: ['data', 'reflectance']
+      },
+      nir08: {
+        href: 'https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/17/S/NB/2023/8/S2B_17SNB_20230801_0_L2A/B8A.tif',
+        type: 'image/tiff; application=geotiff; profile=cloud-optimized',
+        title: 'NIR 2 (band 8A) - 20m',
+        'eo:bands': [
+          {
+            name: 'nir08',
+            common_name: 'nir08',
+            description: 'NIR 2 (band 8A)',
+            center_wavelength: 0.865,
+            full_width_half_max: 0.033
+          }
+        ],
+        gsd: 20,
+        'proj:shape': [5490, 5490],
+        'proj:transform': [20, 0, 499980, 0, -20, 4200000],
+        'raster:bands': [
+          {
+            nodata: 0,
+            data_type: 'uint16',
+            bits_per_sample: 15,
+            spatial_resolution: 20,
+            scale: 0.0001,
+            offset: -0.1
+          }
+        ],
+        roles: ['data', 'reflectance']
+      },
+      nir09: {
+        href: 'https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/17/S/NB/2023/8/S2B_17SNB_20230801_0_L2A/B09.tif',
+        type: 'image/tiff; application=geotiff; profile=cloud-optimized',
+        title: 'NIR 3 (band 9) - 60m',
+        'eo:bands': [
+          {
+            name: 'nir09',
+            common_name: 'nir09',
+            description: 'NIR 3 (band 9)',
+            center_wavelength: 0.945,
+            full_width_half_max: 0.026
+          }
+        ],
+        gsd: 60,
+        'proj:shape': [1830, 1830],
+        'proj:transform': [60, 0, 499980, 0, -60, 4200000],
+        'raster:bands': [
+          {
+            nodata: 0,
+            data_type: 'uint16',
+            bits_per_sample: 15,
+            spatial_resolution: 60,
+            scale: 0.0001,
+            offset: -0.1
+          }
+        ],
+        roles: ['data', 'reflectance']
+      },
+      red: {
+        href: 'https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/17/S/NB/2023/8/S2B_17SNB_20230801_0_L2A/B04.tif',
+        type: 'image/tiff; application=geotiff; profile=cloud-optimized',
+        title: 'Red (band 4) - 10m',
+        'eo:bands': [
+          {
+            name: 'red',
+            common_name: 'red',
+            description: 'Red (band 4)',
+            center_wavelength: 0.665,
+            full_width_half_max: 0.038
+          }
+        ],
+        gsd: 10,
+        'proj:shape': [10980, 10980],
+        'proj:transform': [10, 0, 499980, 0, -10, 4200000],
+        'raster:bands': [
+          {
+            nodata: 0,
+            data_type: 'uint16',
+            bits_per_sample: 15,
+            spatial_resolution: 10,
+            scale: 0.0001,
+            offset: -0.1
+          }
+        ],
+        roles: ['data', 'reflectance']
+      },
+      rededge1: {
+        href: 'https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/17/S/NB/2023/8/S2B_17SNB_20230801_0_L2A/B05.tif',
+        type: 'image/tiff; application=geotiff; profile=cloud-optimized',
+        title: 'Red edge 1 (band 5) - 20m',
+        'eo:bands': [
+          {
+            name: 'rededge1',
+            common_name: 'rededge',
+            description: 'Red edge 1 (band 5)',
+            center_wavelength: 0.704,
+            full_width_half_max: 0.019
+          }
+        ],
+        gsd: 20,
+        'proj:shape': [5490, 5490],
+        'proj:transform': [20, 0, 499980, 0, -20, 4200000],
+        'raster:bands': [
+          {
+            nodata: 0,
+            data_type: 'uint16',
+            bits_per_sample: 15,
+            spatial_resolution: 20,
+            scale: 0.0001,
+            offset: -0.1
+          }
+        ],
+        roles: ['data', 'reflectance']
+      },
+      rededge2: {
+        href: 'https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/17/S/NB/2023/8/S2B_17SNB_20230801_0_L2A/B06.tif',
+        type: 'image/tiff; application=geotiff; profile=cloud-optimized',
+        title: 'Red edge 2 (band 6) - 20m',
+        'eo:bands': [
+          {
+            name: 'rededge2',
+            common_name: 'rededge',
+            description: 'Red edge 2 (band 6)',
+            center_wavelength: 0.74,
+            full_width_half_max: 0.018
+          }
+        ],
+        gsd: 20,
+        'proj:shape': [5490, 5490],
+        'proj:transform': [20, 0, 499980, 0, -20, 4200000],
+        'raster:bands': [
+          {
+            nodata: 0,
+            data_type: 'uint16',
+            bits_per_sample: 15,
+            spatial_resolution: 20,
+            scale: 0.0001,
+            offset: -0.1
+          }
+        ],
+        roles: ['data', 'reflectance']
+      },
+      rededge3: {
+        href: 'https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/17/S/NB/2023/8/S2B_17SNB_20230801_0_L2A/B07.tif',
+        type: 'image/tiff; application=geotiff; profile=cloud-optimized',
+        title: 'Red edge 3 (band 7) - 20m',
+        'eo:bands': [
+          {
+            name: 'rededge3',
+            common_name: 'rededge',
+            description: 'Red edge 3 (band 7)',
+            center_wavelength: 0.783,
+            full_width_half_max: 0.028
+          }
+        ],
+        gsd: 20,
+        'proj:shape': [5490, 5490],
+        'proj:transform': [20, 0, 499980, 0, -20, 4200000],
+        'raster:bands': [
+          {
+            nodata: 0,
+            data_type: 'uint16',
+            bits_per_sample: 15,
+            spatial_resolution: 20,
+            scale: 0.0001,
+            offset: -0.1
+          }
+        ],
+        roles: ['data', 'reflectance']
+      },
+      scl: {
+        href: 'https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/17/S/NB/2023/8/S2B_17SNB_20230801_0_L2A/SCL.tif',
+        type: 'image/tiff; application=geotiff; profile=cloud-optimized',
+        title: 'Scene classification map (SCL)',
+        'proj:shape': [5490, 5490],
+        'proj:transform': [20, 0, 499980, 0, -20, 4200000],
+        'raster:bands': [
+          {
+            nodata: 0,
+            data_type: 'uint8',
+            spatial_resolution: 20
+          }
+        ],
+        roles: ['data', 'reflectance']
+      },
+      swir16: {
+        href: 'https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/17/S/NB/2023/8/S2B_17SNB_20230801_0_L2A/B11.tif',
+        type: 'image/tiff; application=geotiff; profile=cloud-optimized',
+        title: 'SWIR 1 (band 11) - 20m',
+        'eo:bands': [
+          {
+            name: 'swir16',
+            common_name: 'swir16',
+            description: 'SWIR 1 (band 11)',
+            center_wavelength: 1.61,
+            full_width_half_max: 0.143
+          }
+        ],
+        gsd: 20,
+        'proj:shape': [5490, 5490],
+        'proj:transform': [20, 0, 499980, 0, -20, 4200000],
+        'raster:bands': [
+          {
+            nodata: 0,
+            data_type: 'uint16',
+            bits_per_sample: 15,
+            spatial_resolution: 20,
+            scale: 0.0001,
+            offset: -0.1
+          }
+        ],
+        roles: ['data', 'reflectance']
+      },
+      swir22: {
+        href: 'https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/17/S/NB/2023/8/S2B_17SNB_20230801_0_L2A/B12.tif',
+        type: 'image/tiff; application=geotiff; profile=cloud-optimized',
+        title: 'SWIR 2 (band 12) - 20m',
+        'eo:bands': [
+          {
+            name: 'swir22',
+            common_name: 'swir22',
+            description: 'SWIR 2 (band 12)',
+            center_wavelength: 2.19,
+            full_width_half_max: 0.242
+          }
+        ],
+        gsd: 20,
+        'proj:shape': [5490, 5490],
+        'proj:transform': [20, 0, 499980, 0, -20, 4200000],
+        'raster:bands': [
+          {
+            nodata: 0,
+            data_type: 'uint16',
+            bits_per_sample: 15,
+            spatial_resolution: 20,
+            scale: 0.0001,
+            offset: -0.1
+          }
+        ],
+        roles: ['data', 'reflectance']
+      },
+      thumbnail: {
+        href: 'https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/17/S/NB/2023/8/S2B_17SNB_20230801_0_L2A/thumbnail.jpg',
+        type: 'image/jpeg',
+        title: 'Thumbnail image',
+        roles: ['thumbnail']
+      },
+      tileinfo_metadata: {
+        href: 'https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/17/S/NB/2023/8/S2B_17SNB_20230801_0_L2A/tileinfo_metadata.json',
+        type: 'application/json',
+        roles: ['metadata']
+      },
+      visual: {
+        href: 'https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/17/S/NB/2023/8/S2B_17SNB_20230801_0_L2A/TCI.tif',
+        type: 'image/tiff; application=geotiff; profile=cloud-optimized',
+        title: 'True color image',
+        'eo:bands': [
+          {
+            name: 'red',
+            common_name: 'red',
+            description: 'Red (band 4)',
+            center_wavelength: 0.665,
+            full_width_half_max: 0.038
+          },
+          {
+            name: 'green',
+            common_name: 'green',
+            description: 'Green (band 3)',
+            center_wavelength: 0.56,
+            full_width_half_max: 0.045
+          },
+          {
+            name: 'blue',
+            common_name: 'blue',
+            description: 'Blue (band 2)',
+            center_wavelength: 0.49,
+            full_width_half_max: 0.098
+          }
+        ],
+        'proj:shape': [10980, 10980],
+        'proj:transform': [10, 0, 499980, 0, -10, 4200000],
+        roles: ['visual']
+      },
+      wvp: {
+        href: 'https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/17/S/NB/2023/8/S2B_17SNB_20230801_0_L2A/WVP.tif',
+        type: 'image/tiff; application=geotiff; profile=cloud-optimized',
+        title: 'Water vapour (WVP)',
+        'proj:shape': [5490, 5490],
+        'proj:transform': [20, 0, 499980, 0, -20, 4200000],
+        'raster:bands': [
+          {
+            nodata: 0,
+            data_type: 'uint16',
+            bits_per_sample: 15,
+            spatial_resolution: 20,
+            unit: 'cm',
+            scale: 0.001,
+            offset: 0
+          }
+        ],
+        roles: ['data', 'reflectance']
+      },
+      'aot-jp2': {
+        href: 's3://sentinel-s2-l2a/tiles/17/S/NB/2023/8/1/0/AOT.jp2',
+        type: 'image/jp2',
+        title: 'Aerosol optical thickness (AOT)',
+        'proj:shape': [5490, 5490],
+        'proj:transform': [20, 0, 499980, 0, -20, 4200000],
+        'raster:bands': [
+          {
+            nodata: 0,
+            data_type: 'uint16',
+            bits_per_sample: 15,
+            spatial_resolution: 20,
+            scale: 0.001,
+            offset: 0
+          }
+        ],
+        roles: ['data', 'reflectance']
+      },
+      'blue-jp2': {
+        href: 's3://sentinel-s2-l2a/tiles/17/S/NB/2023/8/1/0/B02.jp2',
+        type: 'image/jp2',
+        title: 'Blue (band 2) - 10m',
+        'eo:bands': [
+          {
+            name: 'blue',
+            common_name: 'blue',
+            description: 'Blue (band 2)',
+            center_wavelength: 0.49,
+            full_width_half_max: 0.098
+          }
+        ],
+        gsd: 10,
+        'proj:shape': [10980, 10980],
+        'proj:transform': [10, 0, 499980, 0, -10, 4200000],
+        'raster:bands': [
+          {
+            nodata: 0,
+            data_type: 'uint16',
+            bits_per_sample: 15,
+            spatial_resolution: 10,
+            scale: 0.0001,
+            offset: -0.1
+          }
+        ],
+        roles: ['data', 'reflectance']
+      },
+      'coastal-jp2': {
+        href: 's3://sentinel-s2-l2a/tiles/17/S/NB/2023/8/1/0/B01.jp2',
+        type: 'image/jp2',
+        title: 'Coastal aerosol (band 1) - 60m',
+        'eo:bands': [
+          {
+            name: 'coastal',
+            common_name: 'coastal',
+            description: 'Coastal aerosol (band 1)',
+            center_wavelength: 0.443,
+            full_width_half_max: 0.027
+          }
+        ],
+        gsd: 60,
+        'proj:shape': [1830, 1830],
+        'proj:transform': [60, 0, 499980, 0, -60, 4200000],
+        'raster:bands': [
+          {
+            nodata: 0,
+            data_type: 'uint16',
+            bits_per_sample: 15,
+            spatial_resolution: 60,
+            scale: 0.0001,
+            offset: -0.1
+          }
+        ],
+        roles: ['data', 'reflectance']
+      },
+      'green-jp2': {
+        href: 's3://sentinel-s2-l2a/tiles/17/S/NB/2023/8/1/0/B03.jp2',
+        type: 'image/jp2',
+        title: 'Green (band 3) - 10m',
+        'eo:bands': [
+          {
+            name: 'green',
+            common_name: 'green',
+            description: 'Green (band 3)',
+            center_wavelength: 0.56,
+            full_width_half_max: 0.045
+          }
+        ],
+        gsd: 10,
+        'proj:shape': [10980, 10980],
+        'proj:transform': [10, 0, 499980, 0, -10, 4200000],
+        'raster:bands': [
+          {
+            nodata: 0,
+            data_type: 'uint16',
+            bits_per_sample: 15,
+            spatial_resolution: 10,
+            scale: 0.0001,
+            offset: -0.1
+          }
+        ],
+        roles: ['data', 'reflectance']
+      },
+      'nir-jp2': {
+        href: 's3://sentinel-s2-l2a/tiles/17/S/NB/2023/8/1/0/B08.jp2',
+        type: 'image/jp2',
+        title: 'NIR 1 (band 8) - 10m',
+        'eo:bands': [
+          {
+            name: 'nir',
+            common_name: 'nir',
+            description: 'NIR 1 (band 8)',
+            center_wavelength: 0.842,
+            full_width_half_max: 0.145
+          }
+        ],
+        gsd: 10,
+        'proj:shape': [10980, 10980],
+        'proj:transform': [10, 0, 499980, 0, -10, 4200000],
+        'raster:bands': [
+          {
+            nodata: 0,
+            data_type: 'uint16',
+            bits_per_sample: 15,
+            spatial_resolution: 10,
+            scale: 0.0001,
+            offset: -0.1
+          }
+        ],
+        roles: ['data', 'reflectance']
+      },
+      'nir08-jp2': {
+        href: 's3://sentinel-s2-l2a/tiles/17/S/NB/2023/8/1/0/B8A.jp2',
+        type: 'image/jp2',
+        title: 'NIR 2 (band 8A) - 20m',
+        'eo:bands': [
+          {
+            name: 'nir08',
+            common_name: 'nir08',
+            description: 'NIR 2 (band 8A)',
+            center_wavelength: 0.865,
+            full_width_half_max: 0.033
+          }
+        ],
+        gsd: 20,
+        'proj:shape': [5490, 5490],
+        'proj:transform': [20, 0, 499980, 0, -20, 4200000],
+        'raster:bands': [
+          {
+            nodata: 0,
+            data_type: 'uint16',
+            bits_per_sample: 15,
+            spatial_resolution: 20,
+            scale: 0.0001,
+            offset: -0.1
+          }
+        ],
+        roles: ['data', 'reflectance']
+      },
+      'nir09-jp2': {
+        href: 's3://sentinel-s2-l2a/tiles/17/S/NB/2023/8/1/0/B09.jp2',
+        type: 'image/jp2',
+        title: 'NIR 3 (band 9) - 60m',
+        'eo:bands': [
+          {
+            name: 'nir09',
+            common_name: 'nir09',
+            description: 'NIR 3 (band 9)',
+            center_wavelength: 0.945,
+            full_width_half_max: 0.026
+          }
+        ],
+        gsd: 60,
+        'proj:shape': [1830, 1830],
+        'proj:transform': [60, 0, 499980, 0, -60, 4200000],
+        'raster:bands': [
+          {
+            nodata: 0,
+            data_type: 'uint16',
+            bits_per_sample: 15,
+            spatial_resolution: 60,
+            scale: 0.0001,
+            offset: -0.1
+          }
+        ],
+        roles: ['data', 'reflectance']
+      },
+      'red-jp2': {
+        href: 's3://sentinel-s2-l2a/tiles/17/S/NB/2023/8/1/0/B04.jp2',
+        type: 'image/jp2',
+        title: 'Red (band 4) - 10m',
+        'eo:bands': [
+          {
+            name: 'red',
+            common_name: 'red',
+            description: 'Red (band 4)',
+            center_wavelength: 0.665,
+            full_width_half_max: 0.038
+          }
+        ],
+        gsd: 10,
+        'proj:shape': [10980, 10980],
+        'proj:transform': [10, 0, 499980, 0, -10, 4200000],
+        'raster:bands': [
+          {
+            nodata: 0,
+            data_type: 'uint16',
+            bits_per_sample: 15,
+            spatial_resolution: 10,
+            scale: 0.0001,
+            offset: -0.1
+          }
+        ],
+        roles: ['data', 'reflectance']
+      },
+      'rededge1-jp2': {
+        href: 's3://sentinel-s2-l2a/tiles/17/S/NB/2023/8/1/0/B05.jp2',
+        type: 'image/jp2',
+        title: 'Red edge 1 (band 5) - 20m',
+        'eo:bands': [
+          {
+            name: 'rededge1',
+            common_name: 'rededge',
+            description: 'Red edge 1 (band 5)',
+            center_wavelength: 0.704,
+            full_width_half_max: 0.019
+          }
+        ],
+        gsd: 20,
+        'proj:shape': [5490, 5490],
+        'proj:transform': [20, 0, 499980, 0, -20, 4200000],
+        'raster:bands': [
+          {
+            nodata: 0,
+            data_type: 'uint16',
+            bits_per_sample: 15,
+            spatial_resolution: 20,
+            scale: 0.0001,
+            offset: -0.1
+          }
+        ],
+        roles: ['data', 'reflectance']
+      },
+      'rededge2-jp2': {
+        href: 's3://sentinel-s2-l2a/tiles/17/S/NB/2023/8/1/0/B06.jp2',
+        type: 'image/jp2',
+        title: 'Red edge 2 (band 6) - 20m',
+        'eo:bands': [
+          {
+            name: 'rededge2',
+            common_name: 'rededge',
+            description: 'Red edge 2 (band 6)',
+            center_wavelength: 0.74,
+            full_width_half_max: 0.018
+          }
+        ],
+        gsd: 20,
+        'proj:shape': [5490, 5490],
+        'proj:transform': [20, 0, 499980, 0, -20, 4200000],
+        'raster:bands': [
+          {
+            nodata: 0,
+            data_type: 'uint16',
+            bits_per_sample: 15,
+            spatial_resolution: 20,
+            scale: 0.0001,
+            offset: -0.1
+          }
+        ],
+        roles: ['data', 'reflectance']
+      },
+      'rededge3-jp2': {
+        href: 's3://sentinel-s2-l2a/tiles/17/S/NB/2023/8/1/0/B07.jp2',
+        type: 'image/jp2',
+        title: 'Red edge 3 (band 7) - 20m',
+        'eo:bands': [
+          {
+            name: 'rededge3',
+            common_name: 'rededge',
+            description: 'Red edge 3 (band 7)',
+            center_wavelength: 0.783,
+            full_width_half_max: 0.028
+          }
+        ],
+        gsd: 20,
+        'proj:shape': [5490, 5490],
+        'proj:transform': [20, 0, 499980, 0, -20, 4200000],
+        'raster:bands': [
+          {
+            nodata: 0,
+            data_type: 'uint16',
+            bits_per_sample: 15,
+            spatial_resolution: 20,
+            scale: 0.0001,
+            offset: -0.1
+          }
+        ],
+        roles: ['data', 'reflectance']
+      },
+      'scl-jp2': {
+        href: 's3://sentinel-s2-l2a/tiles/17/S/NB/2023/8/1/0/SCL.jp2',
+        type: 'image/jp2',
+        title: 'Scene classification map (SCL)',
+        'proj:shape': [5490, 5490],
+        'proj:transform': [20, 0, 499980, 0, -20, 4200000],
+        'raster:bands': [
+          {
+            nodata: 0,
+            data_type: 'uint8',
+            spatial_resolution: 20
+          }
+        ],
+        roles: ['data', 'reflectance']
+      },
+      'swir16-jp2': {
+        href: 's3://sentinel-s2-l2a/tiles/17/S/NB/2023/8/1/0/B11.jp2',
+        type: 'image/jp2',
+        title: 'SWIR 1 (band 11) - 20m',
+        'eo:bands': [
+          {
+            name: 'swir16',
+            common_name: 'swir16',
+            description: 'SWIR 1 (band 11)',
+            center_wavelength: 1.61,
+            full_width_half_max: 0.143
+          }
+        ],
+        gsd: 20,
+        'proj:shape': [5490, 5490],
+        'proj:transform': [20, 0, 499980, 0, -20, 4200000],
+        'raster:bands': [
+          {
+            nodata: 0,
+            data_type: 'uint16',
+            bits_per_sample: 15,
+            spatial_resolution: 20,
+            scale: 0.0001,
+            offset: -0.1
+          }
+        ],
+        roles: ['data', 'reflectance']
+      },
+      'swir22-jp2': {
+        href: 's3://sentinel-s2-l2a/tiles/17/S/NB/2023/8/1/0/B12.jp2',
+        type: 'image/jp2',
+        title: 'SWIR 2 (band 12) - 20m',
+        'eo:bands': [
+          {
+            name: 'swir22',
+            common_name: 'swir22',
+            description: 'SWIR 2 (band 12)',
+            center_wavelength: 2.19,
+            full_width_half_max: 0.242
+          }
+        ],
+        gsd: 20,
+        'proj:shape': [5490, 5490],
+        'proj:transform': [20, 0, 499980, 0, -20, 4200000],
+        'raster:bands': [
+          {
+            nodata: 0,
+            data_type: 'uint16',
+            bits_per_sample: 15,
+            spatial_resolution: 20,
+            scale: 0.0001,
+            offset: -0.1
+          }
+        ],
+        roles: ['data', 'reflectance']
+      },
+      'visual-jp2': {
+        href: 's3://sentinel-s2-l2a/tiles/17/S/NB/2023/8/1/0/TCI.jp2',
+        type: 'image/jp2',
+        title: 'True color image',
+        'eo:bands': [
+          {
+            name: 'red',
+            common_name: 'red',
+            description: 'Red (band 4)',
+            center_wavelength: 0.665,
+            full_width_half_max: 0.038
+          },
+          {
+            name: 'green',
+            common_name: 'green',
+            description: 'Green (band 3)',
+            center_wavelength: 0.56,
+            full_width_half_max: 0.045
+          },
+          {
+            name: 'blue',
+            common_name: 'blue',
+            description: 'Blue (band 2)',
+            center_wavelength: 0.49,
+            full_width_half_max: 0.098
+          }
+        ],
+        'proj:shape': [10980, 10980],
+        'proj:transform': [10, 0, 499980, 0, -10, 4200000],
+        roles: ['visual']
+      },
+      'wvp-jp2': {
+        href: 's3://sentinel-s2-l2a/tiles/17/S/NB/2023/8/1/0/WVP.jp2',
+        type: 'image/jp2',
+        title: 'Water vapour (WVP)',
+        'proj:shape': [5490, 5490],
+        'proj:transform': [20, 0, 499980, 0, -20, 4200000],
+        'raster:bands': [
+          {
+            nodata: 0,
+            data_type: 'uint16',
+            bits_per_sample: 15,
+            spatial_resolution: 20,
+            unit: 'cm',
+            scale: 0.001,
+            offset: 0
+          }
+        ],
+        roles: ['data', 'reflectance']
+      }
+    },
+    bbox: [
+      -80.9740087373394, 36.951488600423914, -79.75065723902863,
+      37.947173482649525
+    ],
+    stac_extensions: [
+      'https://stac-extensions.github.io/eo/v1.1.0/schema.json',
+      'https://stac-extensions.github.io/projection/v1.1.0/schema.json',
+      'https://stac-extensions.github.io/view/v1.0.0/schema.json',
+      'https://stac-extensions.github.io/raster/v1.1.0/schema.json',
+      'https://stac-extensions.github.io/grid/v1.0.0/schema.json',
+      'https://stac-extensions.github.io/processing/v1.1.0/schema.json',
+      'https://stac-extensions.github.io/mgrs/v1.0.0/schema.json'
+    ],
+    collection: 'sentinel-2-l2a'
+  },
+  {
+    type: 'Feature',
+    stac_version: '1.0.0',
+    id: 'S2B_17SPB_20230801_0_L2A',
+    properties: {
+      created: '2023-08-02T01:08:07.614Z',
+      platform: 'sentinel-2b',
+      constellation: 'sentinel-2',
+      instruments: ['msi'],
+      'eo:cloud_cover': 11.16913,
+      'proj:epsg': 32617,
+      'mgrs:utm_zone': 17,
+      'mgrs:latitude_band': 'S',
+      'mgrs:grid_square': 'PB',
+      'grid:code': 'MGRS-17SPB',
+      'view:sun_azimuth': 136.848144697532,
+      'view:sun_elevation': 65.15819711905411,
+      's2:degraded_msi_data_percentage': 0.0114,
+      's2:nodata_pixel_percentage': 0,
+      's2:saturated_defective_pixel_percentage': 0,
+      's2:dark_features_percentage': 0.063822,
+      's2:cloud_shadow_percentage': 2.876593,
+      's2:vegetation_percentage': 80.563104,
+      's2:not_vegetated_percentage': 2.370032,
+      's2:water_percentage': 0.658458,
+      's2:unclassified_percentage': 2.298864,
+      's2:medium_proba_clouds_percentage': 3.897442,
+      's2:high_proba_clouds_percentage': 2.817124,
+      's2:thin_cirrus_percentage': 4.454564,
+      's2:snow_ice_percentage': 0,
+      's2:product_type': 'S2MSI2A',
+      's2:processing_baseline': '05.09',
+      's2:product_uri':
+        'S2B_MSIL2A_20230801T155829_N0509_R097_T17SPB_20230801T204743.SAFE',
+      's2:generation_time': '2023-08-01T20:47:43.000000Z',
+      's2:datatake_id': 'GS2B_20230801T155829_033442_N05.09',
+      's2:datatake_type': 'INS-NOBS',
+      's2:datastrip_id':
+        'S2B_OPER_MSI_L2A_DS_2BPS_20230801T204743_S20230801T160859_N05.09',
+      's2:granule_id':
+        'S2B_OPER_MSI_L2A_TL_2BPS_20230801T204743_A033442_T17SPB_N05.09',
+      's2:reflectance_conversion_factor': 0.969933433227093,
+      datetime: '2023-08-01T16:13:02.231000Z',
+      's2:sequence': '0',
+      'earthsearch:s3_path':
+        's3://sentinel-cogs/sentinel-s2-l2a-cogs/17/S/PB/2023/8/S2B_17SPB_20230801_0_L2A',
+      'earthsearch:payload_id':
+        'roda-sentinel2/workflow-sentinel2-to-stac/f61ec783e50eef91e8c1b5f637818e73',
+      'earthsearch:boa_offset_applied': true,
+      'processing:software': {
+        'sentinel2-to-stac': '0.1.1'
+      },
+      updated: '2023-08-02T01:08:07.614Z'
+    },
+    geometry: {
+      type: 'Polygon',
+      coordinates: [
+        [
+          [-79.86191482838464, 37.94207619848921],
+          [-79.87680832296512, 36.95257802860544],
+          [-78.64427857302955, 36.93451998232696],
+          [-78.61306950183968, 37.92336472056608],
+          [-79.86191482838464, 37.94207619848921]
+        ]
+      ]
+    },
+    links: [
+      {
+        rel: 'self',
+        type: 'application/geo+json',
+        href: 'https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/items/S2B_17SPB_20230801_0_L2A'
+      },
+      {
+        rel: 'canonical',
+        href: 's3://sentinel-cogs/sentinel-s2-l2a-cogs/17/S/PB/2023/8/S2B_17SPB_20230801_0_L2A/S2B_17SPB_20230801_0_L2A.json',
+        type: 'application/json'
+      },
+      {
+        rel: 'license',
+        href: 'https://sentinel.esa.int/documents/247904/690755/Sentinel_Data_Legal_Notice'
+      },
+      {
+        rel: 'derived_from',
+        href: 'https://earth-search.aws.element84.com/v1/collections/sentinel-2-l1c/items/S2B_17SPB_20230801_0_L1C',
+        type: 'application/geo+json'
+      },
+      {
+        rel: 'parent',
+        type: 'application/json',
+        href: 'https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a'
+      },
+      {
+        rel: 'collection',
+        type: 'application/json',
+        href: 'https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a'
+      },
+      {
+        rel: 'root',
+        type: 'application/json',
+        href: 'https://earth-search.aws.element84.com/v1'
+      },
+      {
+        rel: 'thumbnail',
+        href: 'https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/items/S2B_17SPB_20230801_0_L2A/thumbnail'
+      }
+    ],
+    assets: {
+      aot: {
+        href: 'https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/17/S/PB/2023/8/S2B_17SPB_20230801_0_L2A/AOT.tif',
+        type: 'image/tiff; application=geotiff; profile=cloud-optimized',
+        title: 'Aerosol optical thickness (AOT)',
+        'proj:shape': [5490, 5490],
+        'proj:transform': [20, 0, 600000, 0, -20, 4200000],
+        'raster:bands': [
+          {
+            nodata: 0,
+            data_type: 'uint16',
+            bits_per_sample: 15,
+            spatial_resolution: 20,
+            scale: 0.001,
+            offset: 0
+          }
+        ],
+        roles: ['data', 'reflectance']
+      },
+      blue: {
+        href: 'https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/17/S/PB/2023/8/S2B_17SPB_20230801_0_L2A/B02.tif',
+        type: 'image/tiff; application=geotiff; profile=cloud-optimized',
+        title: 'Blue (band 2) - 10m',
+        'eo:bands': [
+          {
+            name: 'blue',
+            common_name: 'blue',
+            description: 'Blue (band 2)',
+            center_wavelength: 0.49,
+            full_width_half_max: 0.098
+          }
+        ],
+        gsd: 10,
+        'proj:shape': [10980, 10980],
+        'proj:transform': [10, 0, 600000, 0, -10, 4200000],
+        'raster:bands': [
+          {
+            nodata: 0,
+            data_type: 'uint16',
+            bits_per_sample: 15,
+            spatial_resolution: 10,
+            scale: 0.0001,
+            offset: -0.1
+          }
+        ],
+        roles: ['data', 'reflectance']
+      },
+      coastal: {
+        href: 'https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/17/S/PB/2023/8/S2B_17SPB_20230801_0_L2A/B01.tif',
+        type: 'image/tiff; application=geotiff; profile=cloud-optimized',
+        title: 'Coastal aerosol (band 1) - 60m',
+        'eo:bands': [
+          {
+            name: 'coastal',
+            common_name: 'coastal',
+            description: 'Coastal aerosol (band 1)',
+            center_wavelength: 0.443,
+            full_width_half_max: 0.027
+          }
+        ],
+        gsd: 60,
+        'proj:shape': [1830, 1830],
+        'proj:transform': [60, 0, 600000, 0, -60, 4200000],
+        'raster:bands': [
+          {
+            nodata: 0,
+            data_type: 'uint16',
+            bits_per_sample: 15,
+            spatial_resolution: 60,
+            scale: 0.0001,
+            offset: -0.1
+          }
+        ],
+        roles: ['data', 'reflectance']
+      },
+      granule_metadata: {
+        href: 'https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/17/S/PB/2023/8/S2B_17SPB_20230801_0_L2A/granule_metadata.xml',
+        type: 'application/xml',
+        roles: ['metadata']
+      },
+      green: {
+        href: 'https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/17/S/PB/2023/8/S2B_17SPB_20230801_0_L2A/B03.tif',
+        type: 'image/tiff; application=geotiff; profile=cloud-optimized',
+        title: 'Green (band 3) - 10m',
+        'eo:bands': [
+          {
+            name: 'green',
+            common_name: 'green',
+            description: 'Green (band 3)',
+            center_wavelength: 0.56,
+            full_width_half_max: 0.045
+          }
+        ],
+        gsd: 10,
+        'proj:shape': [10980, 10980],
+        'proj:transform': [10, 0, 600000, 0, -10, 4200000],
+        'raster:bands': [
+          {
+            nodata: 0,
+            data_type: 'uint16',
+            bits_per_sample: 15,
+            spatial_resolution: 10,
+            scale: 0.0001,
+            offset: -0.1
+          }
+        ],
+        roles: ['data', 'reflectance']
+      },
+      nir: {
+        href: 'https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/17/S/PB/2023/8/S2B_17SPB_20230801_0_L2A/B08.tif',
+        type: 'image/tiff; application=geotiff; profile=cloud-optimized',
+        title: 'NIR 1 (band 8) - 10m',
+        'eo:bands': [
+          {
+            name: 'nir',
+            common_name: 'nir',
+            description: 'NIR 1 (band 8)',
+            center_wavelength: 0.842,
+            full_width_half_max: 0.145
+          }
+        ],
+        gsd: 10,
+        'proj:shape': [10980, 10980],
+        'proj:transform': [10, 0, 600000, 0, -10, 4200000],
+        'raster:bands': [
+          {
+            nodata: 0,
+            data_type: 'uint16',
+            bits_per_sample: 15,
+            spatial_resolution: 10,
+            scale: 0.0001,
+            offset: -0.1
+          }
+        ],
+        roles: ['data', 'reflectance']
+      },
+      nir08: {
+        href: 'https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/17/S/PB/2023/8/S2B_17SPB_20230801_0_L2A/B8A.tif',
+        type: 'image/tiff; application=geotiff; profile=cloud-optimized',
+        title: 'NIR 2 (band 8A) - 20m',
+        'eo:bands': [
+          {
+            name: 'nir08',
+            common_name: 'nir08',
+            description: 'NIR 2 (band 8A)',
+            center_wavelength: 0.865,
+            full_width_half_max: 0.033
+          }
+        ],
+        gsd: 20,
+        'proj:shape': [5490, 5490],
+        'proj:transform': [20, 0, 600000, 0, -20, 4200000],
+        'raster:bands': [
+          {
+            nodata: 0,
+            data_type: 'uint16',
+            bits_per_sample: 15,
+            spatial_resolution: 20,
+            scale: 0.0001,
+            offset: -0.1
+          }
+        ],
+        roles: ['data', 'reflectance']
+      },
+      nir09: {
+        href: 'https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/17/S/PB/2023/8/S2B_17SPB_20230801_0_L2A/B09.tif',
+        type: 'image/tiff; application=geotiff; profile=cloud-optimized',
+        title: 'NIR 3 (band 9) - 60m',
+        'eo:bands': [
+          {
+            name: 'nir09',
+            common_name: 'nir09',
+            description: 'NIR 3 (band 9)',
+            center_wavelength: 0.945,
+            full_width_half_max: 0.026
+          }
+        ],
+        gsd: 60,
+        'proj:shape': [1830, 1830],
+        'proj:transform': [60, 0, 600000, 0, -60, 4200000],
+        'raster:bands': [
+          {
+            nodata: 0,
+            data_type: 'uint16',
+            bits_per_sample: 15,
+            spatial_resolution: 60,
+            scale: 0.0001,
+            offset: -0.1
+          }
+        ],
+        roles: ['data', 'reflectance']
+      },
+      red: {
+        href: 'https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/17/S/PB/2023/8/S2B_17SPB_20230801_0_L2A/B04.tif',
+        type: 'image/tiff; application=geotiff; profile=cloud-optimized',
+        title: 'Red (band 4) - 10m',
+        'eo:bands': [
+          {
+            name: 'red',
+            common_name: 'red',
+            description: 'Red (band 4)',
+            center_wavelength: 0.665,
+            full_width_half_max: 0.038
+          }
+        ],
+        gsd: 10,
+        'proj:shape': [10980, 10980],
+        'proj:transform': [10, 0, 600000, 0, -10, 4200000],
+        'raster:bands': [
+          {
+            nodata: 0,
+            data_type: 'uint16',
+            bits_per_sample: 15,
+            spatial_resolution: 10,
+            scale: 0.0001,
+            offset: -0.1
+          }
+        ],
+        roles: ['data', 'reflectance']
+      },
+      rededge1: {
+        href: 'https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/17/S/PB/2023/8/S2B_17SPB_20230801_0_L2A/B05.tif',
+        type: 'image/tiff; application=geotiff; profile=cloud-optimized',
+        title: 'Red edge 1 (band 5) - 20m',
+        'eo:bands': [
+          {
+            name: 'rededge1',
+            common_name: 'rededge',
+            description: 'Red edge 1 (band 5)',
+            center_wavelength: 0.704,
+            full_width_half_max: 0.019
+          }
+        ],
+        gsd: 20,
+        'proj:shape': [5490, 5490],
+        'proj:transform': [20, 0, 600000, 0, -20, 4200000],
+        'raster:bands': [
+          {
+            nodata: 0,
+            data_type: 'uint16',
+            bits_per_sample: 15,
+            spatial_resolution: 20,
+            scale: 0.0001,
+            offset: -0.1
+          }
+        ],
+        roles: ['data', 'reflectance']
+      },
+      rededge2: {
+        href: 'https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/17/S/PB/2023/8/S2B_17SPB_20230801_0_L2A/B06.tif',
+        type: 'image/tiff; application=geotiff; profile=cloud-optimized',
+        title: 'Red edge 2 (band 6) - 20m',
+        'eo:bands': [
+          {
+            name: 'rededge2',
+            common_name: 'rededge',
+            description: 'Red edge 2 (band 6)',
+            center_wavelength: 0.74,
+            full_width_half_max: 0.018
+          }
+        ],
+        gsd: 20,
+        'proj:shape': [5490, 5490],
+        'proj:transform': [20, 0, 600000, 0, -20, 4200000],
+        'raster:bands': [
+          {
+            nodata: 0,
+            data_type: 'uint16',
+            bits_per_sample: 15,
+            spatial_resolution: 20,
+            scale: 0.0001,
+            offset: -0.1
+          }
+        ],
+        roles: ['data', 'reflectance']
+      },
+      rededge3: {
+        href: 'https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/17/S/PB/2023/8/S2B_17SPB_20230801_0_L2A/B07.tif',
+        type: 'image/tiff; application=geotiff; profile=cloud-optimized',
+        title: 'Red edge 3 (band 7) - 20m',
+        'eo:bands': [
+          {
+            name: 'rededge3',
+            common_name: 'rededge',
+            description: 'Red edge 3 (band 7)',
+            center_wavelength: 0.783,
+            full_width_half_max: 0.028
+          }
+        ],
+        gsd: 20,
+        'proj:shape': [5490, 5490],
+        'proj:transform': [20, 0, 600000, 0, -20, 4200000],
+        'raster:bands': [
+          {
+            nodata: 0,
+            data_type: 'uint16',
+            bits_per_sample: 15,
+            spatial_resolution: 20,
+            scale: 0.0001,
+            offset: -0.1
+          }
+        ],
+        roles: ['data', 'reflectance']
+      },
+      scl: {
+        href: 'https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/17/S/PB/2023/8/S2B_17SPB_20230801_0_L2A/SCL.tif',
+        type: 'image/tiff; application=geotiff; profile=cloud-optimized',
+        title: 'Scene classification map (SCL)',
+        'proj:shape': [5490, 5490],
+        'proj:transform': [20, 0, 600000, 0, -20, 4200000],
+        'raster:bands': [
+          {
+            nodata: 0,
+            data_type: 'uint8',
+            spatial_resolution: 20
+          }
+        ],
+        roles: ['data', 'reflectance']
+      },
+      swir16: {
+        href: 'https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/17/S/PB/2023/8/S2B_17SPB_20230801_0_L2A/B11.tif',
+        type: 'image/tiff; application=geotiff; profile=cloud-optimized',
+        title: 'SWIR 1 (band 11) - 20m',
+        'eo:bands': [
+          {
+            name: 'swir16',
+            common_name: 'swir16',
+            description: 'SWIR 1 (band 11)',
+            center_wavelength: 1.61,
+            full_width_half_max: 0.143
+          }
+        ],
+        gsd: 20,
+        'proj:shape': [5490, 5490],
+        'proj:transform': [20, 0, 600000, 0, -20, 4200000],
+        'raster:bands': [
+          {
+            nodata: 0,
+            data_type: 'uint16',
+            bits_per_sample: 15,
+            spatial_resolution: 20,
+            scale: 0.0001,
+            offset: -0.1
+          }
+        ],
+        roles: ['data', 'reflectance']
+      },
+      swir22: {
+        href: 'https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/17/S/PB/2023/8/S2B_17SPB_20230801_0_L2A/B12.tif',
+        type: 'image/tiff; application=geotiff; profile=cloud-optimized',
+        title: 'SWIR 2 (band 12) - 20m',
+        'eo:bands': [
+          {
+            name: 'swir22',
+            common_name: 'swir22',
+            description: 'SWIR 2 (band 12)',
+            center_wavelength: 2.19,
+            full_width_half_max: 0.242
+          }
+        ],
+        gsd: 20,
+        'proj:shape': [5490, 5490],
+        'proj:transform': [20, 0, 600000, 0, -20, 4200000],
+        'raster:bands': [
+          {
+            nodata: 0,
+            data_type: 'uint16',
+            bits_per_sample: 15,
+            spatial_resolution: 20,
+            scale: 0.0001,
+            offset: -0.1
+          }
+        ],
+        roles: ['data', 'reflectance']
+      },
+      thumbnail: {
+        href: 'https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/17/S/PB/2023/8/S2B_17SPB_20230801_0_L2A/thumbnail.jpg',
+        type: 'image/jpeg',
+        title: 'Thumbnail image',
+        roles: ['thumbnail']
+      },
+      tileinfo_metadata: {
+        href: 'https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/17/S/PB/2023/8/S2B_17SPB_20230801_0_L2A/tileinfo_metadata.json',
+        type: 'application/json',
+        roles: ['metadata']
+      },
+      visual: {
+        href: 'https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/17/S/PB/2023/8/S2B_17SPB_20230801_0_L2A/TCI.tif',
+        type: 'image/tiff; application=geotiff; profile=cloud-optimized',
+        title: 'True color image',
+        'eo:bands': [
+          {
+            name: 'red',
+            common_name: 'red',
+            description: 'Red (band 4)',
+            center_wavelength: 0.665,
+            full_width_half_max: 0.038
+          },
+          {
+            name: 'green',
+            common_name: 'green',
+            description: 'Green (band 3)',
+            center_wavelength: 0.56,
+            full_width_half_max: 0.045
+          },
+          {
+            name: 'blue',
+            common_name: 'blue',
+            description: 'Blue (band 2)',
+            center_wavelength: 0.49,
+            full_width_half_max: 0.098
+          }
+        ],
+        'proj:shape': [10980, 10980],
+        'proj:transform': [10, 0, 600000, 0, -10, 4200000],
+        roles: ['visual']
+      },
+      wvp: {
+        href: 'https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/17/S/PB/2023/8/S2B_17SPB_20230801_0_L2A/WVP.tif',
+        type: 'image/tiff; application=geotiff; profile=cloud-optimized',
+        title: 'Water vapour (WVP)',
+        'proj:shape': [5490, 5490],
+        'proj:transform': [20, 0, 600000, 0, -20, 4200000],
+        'raster:bands': [
+          {
+            nodata: 0,
+            data_type: 'uint16',
+            bits_per_sample: 15,
+            spatial_resolution: 20,
+            unit: 'cm',
+            scale: 0.001,
+            offset: 0
+          }
+        ],
+        roles: ['data', 'reflectance']
+      },
+      'aot-jp2': {
+        href: 's3://sentinel-s2-l2a/tiles/17/S/PB/2023/8/1/0/AOT.jp2',
+        type: 'image/jp2',
+        title: 'Aerosol optical thickness (AOT)',
+        'proj:shape': [5490, 5490],
+        'proj:transform': [20, 0, 600000, 0, -20, 4200000],
+        'raster:bands': [
+          {
+            nodata: 0,
+            data_type: 'uint16',
+            bits_per_sample: 15,
+            spatial_resolution: 20,
+            scale: 0.001,
+            offset: 0
+          }
+        ],
+        roles: ['data', 'reflectance']
+      },
+      'blue-jp2': {
+        href: 's3://sentinel-s2-l2a/tiles/17/S/PB/2023/8/1/0/B02.jp2',
+        type: 'image/jp2',
+        title: 'Blue (band 2) - 10m',
+        'eo:bands': [
+          {
+            name: 'blue',
+            common_name: 'blue',
+            description: 'Blue (band 2)',
+            center_wavelength: 0.49,
+            full_width_half_max: 0.098
+          }
+        ],
+        gsd: 10,
+        'proj:shape': [10980, 10980],
+        'proj:transform': [10, 0, 600000, 0, -10, 4200000],
+        'raster:bands': [
+          {
+            nodata: 0,
+            data_type: 'uint16',
+            bits_per_sample: 15,
+            spatial_resolution: 10,
+            scale: 0.0001,
+            offset: -0.1
+          }
+        ],
+        roles: ['data', 'reflectance']
+      },
+      'coastal-jp2': {
+        href: 's3://sentinel-s2-l2a/tiles/17/S/PB/2023/8/1/0/B01.jp2',
+        type: 'image/jp2',
+        title: 'Coastal aerosol (band 1) - 60m',
+        'eo:bands': [
+          {
+            name: 'coastal',
+            common_name: 'coastal',
+            description: 'Coastal aerosol (band 1)',
+            center_wavelength: 0.443,
+            full_width_half_max: 0.027
+          }
+        ],
+        gsd: 60,
+        'proj:shape': [1830, 1830],
+        'proj:transform': [60, 0, 600000, 0, -60, 4200000],
+        'raster:bands': [
+          {
+            nodata: 0,
+            data_type: 'uint16',
+            bits_per_sample: 15,
+            spatial_resolution: 60,
+            scale: 0.0001,
+            offset: -0.1
+          }
+        ],
+        roles: ['data', 'reflectance']
+      },
+      'green-jp2': {
+        href: 's3://sentinel-s2-l2a/tiles/17/S/PB/2023/8/1/0/B03.jp2',
+        type: 'image/jp2',
+        title: 'Green (band 3) - 10m',
+        'eo:bands': [
+          {
+            name: 'green',
+            common_name: 'green',
+            description: 'Green (band 3)',
+            center_wavelength: 0.56,
+            full_width_half_max: 0.045
+          }
+        ],
+        gsd: 10,
+        'proj:shape': [10980, 10980],
+        'proj:transform': [10, 0, 600000, 0, -10, 4200000],
+        'raster:bands': [
+          {
+            nodata: 0,
+            data_type: 'uint16',
+            bits_per_sample: 15,
+            spatial_resolution: 10,
+            scale: 0.0001,
+            offset: -0.1
+          }
+        ],
+        roles: ['data', 'reflectance']
+      },
+      'nir-jp2': {
+        href: 's3://sentinel-s2-l2a/tiles/17/S/PB/2023/8/1/0/B08.jp2',
+        type: 'image/jp2',
+        title: 'NIR 1 (band 8) - 10m',
+        'eo:bands': [
+          {
+            name: 'nir',
+            common_name: 'nir',
+            description: 'NIR 1 (band 8)',
+            center_wavelength: 0.842,
+            full_width_half_max: 0.145
+          }
+        ],
+        gsd: 10,
+        'proj:shape': [10980, 10980],
+        'proj:transform': [10, 0, 600000, 0, -10, 4200000],
+        'raster:bands': [
+          {
+            nodata: 0,
+            data_type: 'uint16',
+            bits_per_sample: 15,
+            spatial_resolution: 10,
+            scale: 0.0001,
+            offset: -0.1
+          }
+        ],
+        roles: ['data', 'reflectance']
+      },
+      'nir08-jp2': {
+        href: 's3://sentinel-s2-l2a/tiles/17/S/PB/2023/8/1/0/B8A.jp2',
+        type: 'image/jp2',
+        title: 'NIR 2 (band 8A) - 20m',
+        'eo:bands': [
+          {
+            name: 'nir08',
+            common_name: 'nir08',
+            description: 'NIR 2 (band 8A)',
+            center_wavelength: 0.865,
+            full_width_half_max: 0.033
+          }
+        ],
+        gsd: 20,
+        'proj:shape': [5490, 5490],
+        'proj:transform': [20, 0, 600000, 0, -20, 4200000],
+        'raster:bands': [
+          {
+            nodata: 0,
+            data_type: 'uint16',
+            bits_per_sample: 15,
+            spatial_resolution: 20,
+            scale: 0.0001,
+            offset: -0.1
+          }
+        ],
+        roles: ['data', 'reflectance']
+      },
+      'nir09-jp2': {
+        href: 's3://sentinel-s2-l2a/tiles/17/S/PB/2023/8/1/0/B09.jp2',
+        type: 'image/jp2',
+        title: 'NIR 3 (band 9) - 60m',
+        'eo:bands': [
+          {
+            name: 'nir09',
+            common_name: 'nir09',
+            description: 'NIR 3 (band 9)',
+            center_wavelength: 0.945,
+            full_width_half_max: 0.026
+          }
+        ],
+        gsd: 60,
+        'proj:shape': [1830, 1830],
+        'proj:transform': [60, 0, 600000, 0, -60, 4200000],
+        'raster:bands': [
+          {
+            nodata: 0,
+            data_type: 'uint16',
+            bits_per_sample: 15,
+            spatial_resolution: 60,
+            scale: 0.0001,
+            offset: -0.1
+          }
+        ],
+        roles: ['data', 'reflectance']
+      },
+      'red-jp2': {
+        href: 's3://sentinel-s2-l2a/tiles/17/S/PB/2023/8/1/0/B04.jp2',
+        type: 'image/jp2',
+        title: 'Red (band 4) - 10m',
+        'eo:bands': [
+          {
+            name: 'red',
+            common_name: 'red',
+            description: 'Red (band 4)',
+            center_wavelength: 0.665,
+            full_width_half_max: 0.038
+          }
+        ],
+        gsd: 10,
+        'proj:shape': [10980, 10980],
+        'proj:transform': [10, 0, 600000, 0, -10, 4200000],
+        'raster:bands': [
+          {
+            nodata: 0,
+            data_type: 'uint16',
+            bits_per_sample: 15,
+            spatial_resolution: 10,
+            scale: 0.0001,
+            offset: -0.1
+          }
+        ],
+        roles: ['data', 'reflectance']
+      },
+      'rededge1-jp2': {
+        href: 's3://sentinel-s2-l2a/tiles/17/S/PB/2023/8/1/0/B05.jp2',
+        type: 'image/jp2',
+        title: 'Red edge 1 (band 5) - 20m',
+        'eo:bands': [
+          {
+            name: 'rededge1',
+            common_name: 'rededge',
+            description: 'Red edge 1 (band 5)',
+            center_wavelength: 0.704,
+            full_width_half_max: 0.019
+          }
+        ],
+        gsd: 20,
+        'proj:shape': [5490, 5490],
+        'proj:transform': [20, 0, 600000, 0, -20, 4200000],
+        'raster:bands': [
+          {
+            nodata: 0,
+            data_type: 'uint16',
+            bits_per_sample: 15,
+            spatial_resolution: 20,
+            scale: 0.0001,
+            offset: -0.1
+          }
+        ],
+        roles: ['data', 'reflectance']
+      },
+      'rededge2-jp2': {
+        href: 's3://sentinel-s2-l2a/tiles/17/S/PB/2023/8/1/0/B06.jp2',
+        type: 'image/jp2',
+        title: 'Red edge 2 (band 6) - 20m',
+        'eo:bands': [
+          {
+            name: 'rededge2',
+            common_name: 'rededge',
+            description: 'Red edge 2 (band 6)',
+            center_wavelength: 0.74,
+            full_width_half_max: 0.018
+          }
+        ],
+        gsd: 20,
+        'proj:shape': [5490, 5490],
+        'proj:transform': [20, 0, 600000, 0, -20, 4200000],
+        'raster:bands': [
+          {
+            nodata: 0,
+            data_type: 'uint16',
+            bits_per_sample: 15,
+            spatial_resolution: 20,
+            scale: 0.0001,
+            offset: -0.1
+          }
+        ],
+        roles: ['data', 'reflectance']
+      },
+      'rededge3-jp2': {
+        href: 's3://sentinel-s2-l2a/tiles/17/S/PB/2023/8/1/0/B07.jp2',
+        type: 'image/jp2',
+        title: 'Red edge 3 (band 7) - 20m',
+        'eo:bands': [
+          {
+            name: 'rededge3',
+            common_name: 'rededge',
+            description: 'Red edge 3 (band 7)',
+            center_wavelength: 0.783,
+            full_width_half_max: 0.028
+          }
+        ],
+        gsd: 20,
+        'proj:shape': [5490, 5490],
+        'proj:transform': [20, 0, 600000, 0, -20, 4200000],
+        'raster:bands': [
+          {
+            nodata: 0,
+            data_type: 'uint16',
+            bits_per_sample: 15,
+            spatial_resolution: 20,
+            scale: 0.0001,
+            offset: -0.1
+          }
+        ],
+        roles: ['data', 'reflectance']
+      },
+      'scl-jp2': {
+        href: 's3://sentinel-s2-l2a/tiles/17/S/PB/2023/8/1/0/SCL.jp2',
+        type: 'image/jp2',
+        title: 'Scene classification map (SCL)',
+        'proj:shape': [5490, 5490],
+        'proj:transform': [20, 0, 600000, 0, -20, 4200000],
+        'raster:bands': [
+          {
+            nodata: 0,
+            data_type: 'uint8',
+            spatial_resolution: 20
+          }
+        ],
+        roles: ['data', 'reflectance']
+      },
+      'swir16-jp2': {
+        href: 's3://sentinel-s2-l2a/tiles/17/S/PB/2023/8/1/0/B11.jp2',
+        type: 'image/jp2',
+        title: 'SWIR 1 (band 11) - 20m',
+        'eo:bands': [
+          {
+            name: 'swir16',
+            common_name: 'swir16',
+            description: 'SWIR 1 (band 11)',
+            center_wavelength: 1.61,
+            full_width_half_max: 0.143
+          }
+        ],
+        gsd: 20,
+        'proj:shape': [5490, 5490],
+        'proj:transform': [20, 0, 600000, 0, -20, 4200000],
+        'raster:bands': [
+          {
+            nodata: 0,
+            data_type: 'uint16',
+            bits_per_sample: 15,
+            spatial_resolution: 20,
+            scale: 0.0001,
+            offset: -0.1
+          }
+        ],
+        roles: ['data', 'reflectance']
+      },
+      'swir22-jp2': {
+        href: 's3://sentinel-s2-l2a/tiles/17/S/PB/2023/8/1/0/B12.jp2',
+        type: 'image/jp2',
+        title: 'SWIR 2 (band 12) - 20m',
+        'eo:bands': [
+          {
+            name: 'swir22',
+            common_name: 'swir22',
+            description: 'SWIR 2 (band 12)',
+            center_wavelength: 2.19,
+            full_width_half_max: 0.242
+          }
+        ],
+        gsd: 20,
+        'proj:shape': [5490, 5490],
+        'proj:transform': [20, 0, 600000, 0, -20, 4200000],
+        'raster:bands': [
+          {
+            nodata: 0,
+            data_type: 'uint16',
+            bits_per_sample: 15,
+            spatial_resolution: 20,
+            scale: 0.0001,
+            offset: -0.1
+          }
+        ],
+        roles: ['data', 'reflectance']
+      },
+      'visual-jp2': {
+        href: 's3://sentinel-s2-l2a/tiles/17/S/PB/2023/8/1/0/TCI.jp2',
+        type: 'image/jp2',
+        title: 'True color image',
+        'eo:bands': [
+          {
+            name: 'red',
+            common_name: 'red',
+            description: 'Red (band 4)',
+            center_wavelength: 0.665,
+            full_width_half_max: 0.038
+          },
+          {
+            name: 'green',
+            common_name: 'green',
+            description: 'Green (band 3)',
+            center_wavelength: 0.56,
+            full_width_half_max: 0.045
+          },
+          {
+            name: 'blue',
+            common_name: 'blue',
+            description: 'Blue (band 2)',
+            center_wavelength: 0.49,
+            full_width_half_max: 0.098
+          }
+        ],
+        'proj:shape': [10980, 10980],
+        'proj:transform': [10, 0, 600000, 0, -10, 4200000],
+        roles: ['visual']
+      },
+      'wvp-jp2': {
+        href: 's3://sentinel-s2-l2a/tiles/17/S/PB/2023/8/1/0/WVP.jp2',
+        type: 'image/jp2',
+        title: 'Water vapour (WVP)',
+        'proj:shape': [5490, 5490],
+        'proj:transform': [20, 0, 600000, 0, -20, 4200000],
+        'raster:bands': [
+          {
+            nodata: 0,
+            data_type: 'uint16',
+            bits_per_sample: 15,
+            spatial_resolution: 20,
+            unit: 'cm',
+            scale: 0.001,
+            offset: 0
+          }
+        ],
+        roles: ['data', 'reflectance']
+      }
+    },
+    bbox: [
+      -79.87680832296512, 36.93451998232696, -78.61306950183968,
+      37.94207619848921
+    ],
+    stac_extensions: [
+      'https://stac-extensions.github.io/mgrs/v1.0.0/schema.json',
+      'https://stac-extensions.github.io/processing/v1.1.0/schema.json',
+      'https://stac-extensions.github.io/grid/v1.0.0/schema.json',
+      'https://stac-extensions.github.io/raster/v1.1.0/schema.json',
+      'https://stac-extensions.github.io/view/v1.0.0/schema.json',
+      'https://stac-extensions.github.io/projection/v1.1.0/schema.json',
+      'https://stac-extensions.github.io/eo/v1.1.0/schema.json'
+    ],
+    collection: 'sentinel-2-l2a'
+  }
+]

--- a/src/utils/dataHelper.js
+++ b/src/utils/dataHelper.js
@@ -33,35 +33,25 @@ export async function loadLocalGridData() {
 }
 
 export function isSceneInCart(sceneObject) {
-  let itemInCart = false
-  store.getState().mainSlice.cartItems.forEach((cartItem) => {
-    if (cartItem.id === sceneObject.id) {
-      itemInCart = true
-    }
-  })
-  return itemInCart
+  const cartItems = store.getState().mainSlice.cartItems
+  return cartItems.some((cartItem) => cartItem.id === sceneObject.id)
 }
 
 export function numberOfSelectedInCart(results) {
-  let count = 0
-  results.forEach((result) => {
-    const sceneInCart = isSceneInCart(result)
-    if (sceneInCart) {
-      count++
+  const cartItems = store.getState().mainSlice.cartItems
+  return results.reduce((count, result) => {
+    if (cartItems.some((cartItem) => cartItem.id === result.id)) {
+      return count + 1
     }
-  })
-  return count
+    return count
+  }, 0)
 }
 
 export function areAllScenesSelectedInCart(results) {
-  let allInCart = true
-  results.forEach((result) => {
-    const sceneInCart = isSceneInCart(result)
-    if (!sceneInCart) {
-      allInCart = false
-    }
-  })
-  return allInCart
+  const cartItems = store.getState().mainSlice.cartItems
+  return results.every((result) =>
+    cartItems.some((cartItem) => cartItem.id === result.id)
+  )
 }
 
 export function setScenesForCartLayer() {

--- a/src/utils/dataHelper.js
+++ b/src/utils/dataHelper.js
@@ -1,6 +1,12 @@
 import { GetCollectionQueryablesService } from '../services/get-queryables-service'
 import { GetCollectionAggregationsService } from '../services/get-aggregations-service'
 import { LoadLocalGridDataService } from '../services/get-local-grid-data-json-service'
+import { store } from '../redux/store'
+import {
+  cartFootprintLayerStyle,
+  addDataToLayer,
+  clearLayer
+} from './mapHelper'
 
 export async function buildCollectionsData(collections) {
   for (const collection of collections.collections) {
@@ -24,4 +30,52 @@ export async function loadLocalGridData() {
   dataFiles.map(async function (d) {
     await LoadLocalGridDataService(d)
   })
+}
+
+export function isSceneInCart(sceneObject) {
+  let itemInCart = false
+  store.getState().mainSlice.cartItems.forEach((cartItem) => {
+    if (cartItem.id === sceneObject.id) {
+      itemInCart = true
+    }
+  })
+  return itemInCart
+}
+
+export function numberOfSelectedInCart(results) {
+  let count = 0
+  results.forEach((result) => {
+    const sceneInCart = isSceneInCart(result)
+    if (sceneInCart) {
+      count++
+    }
+  })
+  return count
+}
+
+export function areAllScenesSelectedInCart(results) {
+  let allInCart = true
+  results.forEach((result) => {
+    const sceneInCart = isSceneInCart(result)
+    if (!sceneInCart) {
+      allInCart = false
+    }
+  })
+  return allInCart
+}
+
+export function setScenesForCartLayer() {
+  if (store.getState().mainSlice.cartItems.length === 0) {
+    clearLayer('cartFootprintsLayer')
+    return
+  }
+  const cartGeojson = {
+    type: 'FeatureCollection',
+    features: store.getState().mainSlice.cartItems
+  }
+  const options = {
+    style: cartFootprintLayerStyle,
+    interactive: false
+  }
+  addDataToLayer(cartGeojson, 'cartFootprintsLayer', options)
 }

--- a/src/utils/dataHelper.test.js
+++ b/src/utils/dataHelper.test.js
@@ -1,5 +1,3 @@
-// dataHelper.test.js
-
 import { vi } from 'vitest'
 import { store } from '../redux/store'
 import {
@@ -27,31 +25,24 @@ describe('dataHelper', () => {
   describe('isSceneInCart', () => {
     it('returns true if scene is in cart', () => {
       const mockCart = [{ id: '1' }, { id: '2' }]
-
       vi.spyOn(store, 'getState').mockReturnValue({
         mainSlice: {
           cartItems: mockCart
         }
       })
-
       const scene = { id: '1' }
       const result = isSceneInCart(scene)
-
       expect(result).toBe(true)
     })
-
     it('returns false if scene is not in cart', () => {
       const mockCart = [{ id: '1' }, { id: '2' }]
-
       vi.spyOn(store, 'getState').mockReturnValue({
         mainSlice: {
           cartItems: mockCart
         }
       })
-
       const scene = { id: '3' }
       const result = isSceneInCart(scene)
-
       expect(result).toBe(false)
     })
   })
@@ -73,33 +64,24 @@ describe('dataHelper', () => {
   describe('areAllScenesSelectedInCart', () => {
     it('returns true if all scenes are in cart', () => {
       const mockCart = [{ id: '1' }, { id: '2' }]
-
       vi.spyOn(store, 'getState').mockReturnValue({
         mainSlice: {
           cartItems: mockCart
         }
       })
-
       const mockResults = [{ id: '1' }, { id: '2' }]
-
       const allInCart = areAllScenesSelectedInCart(mockResults)
-
       expect(allInCart).toBe(true)
     })
-
     it('returns false if some scenes not in cart', () => {
       const mockCart = [{ id: '1' }, { id: '2' }]
-
       vi.spyOn(store, 'getState').mockReturnValue({
         mainSlice: {
           cartItems: mockCart
         }
       })
-
       const mockResults = [{ id: '1' }, { id: '3' }]
-
       const allInCart = areAllScenesSelectedInCart(mockResults)
-
       expect(allInCart).toBe(false)
     })
   })

--- a/src/utils/dataHelper.test.js
+++ b/src/utils/dataHelper.test.js
@@ -1,0 +1,138 @@
+// dataHelper.test.js
+
+import { vi } from 'vitest'
+import { store } from '../redux/store'
+import {
+  loadLocalGridData,
+  isSceneInCart,
+  numberOfSelectedInCart,
+  areAllScenesSelectedInCart,
+  setScenesForCartLayer
+} from './dataHelper'
+import * as getLocalGridDataService from '../services/get-local-grid-data-json-service'
+import * as MapHelper from './mapHelper'
+
+describe('dataHelper', () => {
+  describe('loadLocalGridData', () => {
+    it('calls service to load grid data', async () => {
+      const spyLoadLocalGridDataService = vi.spyOn(
+        getLocalGridDataService,
+        'LoadLocalGridDataService'
+      )
+      await loadLocalGridData()
+      expect(spyLoadLocalGridDataService).toHaveBeenCalledTimes(4)
+    })
+  })
+
+  describe('isSceneInCart', () => {
+    it('returns true if scene is in cart', () => {
+      const mockCart = [{ id: '1' }, { id: '2' }]
+
+      vi.spyOn(store, 'getState').mockReturnValue({
+        mainSlice: {
+          cartItems: mockCart
+        }
+      })
+
+      const scene = { id: '1' }
+      const result = isSceneInCart(scene)
+
+      expect(result).toBe(true)
+    })
+
+    it('returns false if scene is not in cart', () => {
+      const mockCart = [{ id: '1' }, { id: '2' }]
+
+      vi.spyOn(store, 'getState').mockReturnValue({
+        mainSlice: {
+          cartItems: mockCart
+        }
+      })
+
+      const scene = { id: '3' }
+      const result = isSceneInCart(scene)
+
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('numberOfSelectedInCart', () => {
+    it('returns number of selected scenes in cart', () => {
+      const mockCart = [{ id: '1' }, { id: '2' }]
+      vi.spyOn(store, 'getState').mockReturnValue({
+        mainSlice: {
+          cartItems: mockCart
+        }
+      })
+      const mockResults = [{ id: '1' }, { id: '3' }]
+      const count = numberOfSelectedInCart(mockResults)
+      expect(count).toBe(1)
+    })
+  })
+
+  describe('areAllScenesSelectedInCart', () => {
+    it('returns true if all scenes are in cart', () => {
+      const mockCart = [{ id: '1' }, { id: '2' }]
+
+      vi.spyOn(store, 'getState').mockReturnValue({
+        mainSlice: {
+          cartItems: mockCart
+        }
+      })
+
+      const mockResults = [{ id: '1' }, { id: '2' }]
+
+      const allInCart = areAllScenesSelectedInCart(mockResults)
+
+      expect(allInCart).toBe(true)
+    })
+
+    it('returns false if some scenes not in cart', () => {
+      const mockCart = [{ id: '1' }, { id: '2' }]
+
+      vi.spyOn(store, 'getState').mockReturnValue({
+        mainSlice: {
+          cartItems: mockCart
+        }
+      })
+
+      const mockResults = [{ id: '1' }, { id: '3' }]
+
+      const allInCart = areAllScenesSelectedInCart(mockResults)
+
+      expect(allInCart).toBe(false)
+    })
+  })
+
+  describe('setScenesForCartLayer', () => {
+    it('clears layer if no cart items', () => {
+      const mockEmptyCart = []
+      vi.spyOn(store, 'getState').mockReturnValue({
+        mainSlice: {
+          cartItems: mockEmptyCart
+        }
+      })
+      const spyClearLayer = vi.spyOn(MapHelper, 'clearLayer')
+      setScenesForCartLayer()
+      expect(spyClearLayer).toHaveBeenCalledWith('cartFootprintsLayer')
+    })
+    it('sets geojson and options for cart layer', () => {
+      const mockCartItems = [{ id: '1' }, { id: '2' }]
+      vi.spyOn(store, 'getState').mockReturnValue({
+        mainSlice: {
+          cartItems: mockCartItems
+        }
+      })
+      const spyAddDataToLayer = vi.spyOn(MapHelper, 'addDataToLayer')
+      setScenesForCartLayer()
+      expect(spyAddDataToLayer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'FeatureCollection',
+          features: mockCartItems
+        }),
+        'cartFootprintsLayer',
+        expect.any(Object)
+      )
+    })
+  })
+})

--- a/src/utils/mapHelper.js
+++ b/src/utils/mapHelper.js
@@ -42,6 +42,15 @@ export const clickedFootprintLayerStyle = {
   pane: 'searchResults'
 }
 
+export const cartFootprintLayerStyle = {
+  color: '#ad5c11',
+  weight: 3,
+  opacity: 1,
+  fillOpacity: 0.1,
+  fillColor: '#ad5c11',
+  pane: 'searchResults'
+}
+
 const customSearchPointIconStyle = L.icon({
   iconSize: [25, 41],
   iconAnchor: [10, 41],
@@ -140,6 +149,9 @@ export function addDataToLayer(geojson, layerName, options) {
           L.geoJSON(geojson).addTo(layer)
         }
       }
+      if (layer.layer_name === 'cartFootprintsLayer') {
+        layer.bringToFront()
+      }
     })
   }
 }
@@ -160,7 +172,11 @@ export function clearAllLayers() {
   const map = store.getState().mainSlice.map
   if (map && Object.keys(map).length > 0) {
     map.eachLayer(function (layer) {
-      if (layer.layer_name && layer.layer_name !== 'drawBoundsLayer') {
+      if (
+        layer.layer_name &&
+        layer.layer_name !== 'drawBoundsLayer' &&
+        layer.layer_name !== 'cartFootprintsLayer'
+      ) {
         layer.clearLayers()
       }
     })
@@ -293,6 +309,10 @@ export function mapCallDebounceNewSearch() {
 export const debounceTitilerOverlay = debounce(() => addImageOverlay(), 800)
 
 function addImageOverlay() {
+  if (!store.getState().mainSlice.currentPopupResult) {
+    store.dispatch(setSearchLoading(false))
+    return
+  }
   const sceneTilerURL =
     store.getState().mainSlice.appConfig.SCENE_TILER_URL || ''
   const _currentPopupResult = store.getState().mainSlice.currentPopupResult

--- a/src/utils/mapHelper.js
+++ b/src/utils/mapHelper.js
@@ -121,7 +121,6 @@ export function mapClickHandler(e) {
             if (intersectingFeatures.length > 0) {
               // push to store
               store.dispatch(setClickResults(intersectingFeatures))
-              console.log(intersectingFeatures)
               store.dispatch(setShowPopupModal(true))
             } else {
               // clear store

--- a/src/utils/mapHelper.js
+++ b/src/utils/mapHelper.js
@@ -121,6 +121,7 @@ export function mapClickHandler(e) {
             if (intersectingFeatures.length > 0) {
               // push to store
               store.dispatch(setClickResults(intersectingFeatures))
+              console.log(intersectingFeatures)
               store.dispatch(setShowPopupModal(true))
             } else {
               // clear store


### PR DESCRIPTION
**Related Issue(s):**

- NA

**Proposed Changes:**

1. Cart button to `Add all to cart` & `Add/Remove scene from cart` added to search bar if `CART_ENABLED` set to true in `config.json`
2. Button clicks add and/or remove items from cart per AC
3. Fix map legend to always show 'Scenes in Cart' symbology when `CART_ENABLED` set to true in `config.json` and Items exist in cart

**BONUS 1:** PopupResults component updated to allow users to minimize/maximize popup results component content

**BONUS 2:** Cart items are now shown in layer on map if `CART_ENABLED` set to true in `config.json` and Items exist in cart (not this was out of scope so placeholder solution implemented in this ticket but will be revisited in future team discussions for follow up with better UX)

> NOTE: number of diffs is inflated by adding mocks, real number of diffs is closer to `900 additions` (this subtracts the 1,960 coming from `shared-mocks.js`) 😄 

### To test:

- all unit tests pass 🍏 

**Test cart not enabled**
- set `CART_ENABLED` to `false` in `config.json`
- load app
- click search
- zoom in until you can click on scenes
- click on any grid or individual scenes
- confirm clicked results show in popup results
- confirm `Add all scenes to cart` button does not render
- confirm `Add scene to cart` button does not render

**Test cart enabled buttons in popup**
- set `CART_ENABLED` to `true` in `config.json`
- load app
- click search
- zoom in until you can click on scenes
- click search again if needed
- click on any grid or individual scenes
- confirm clicked results show in popup results
- confirm `Add all scenes to cart` button renders in popup
- confirm `Add scene to cart` button renders in popup

**Test `Add/remove scene to cart` button**
- load app
- search
- click on scene so that more than one scene is clicked
- click `Add scene to cart` button 
- confirm button text changes to say 'Remove scene from cart'
- confirm cart button in top search bar reflects 1 scene in cart
- confirm summary text in top of popup shows '(1 in cart)'
- confirm legend shows 'Scenes in cart' symbology
- confirm map outline shows orange for footprint added to cart
- click 'Remove scene from cart' button
- confirm button text changes to say `Add scene to cart`
- confirm cart button in top search bar reflects 0 and is no longer green
- confirm summary text in top of popup no longer shows '(1 in cart)'
- confirm legend no longer shows 'Scenes in cart' symbology
- confirm map outline no longer shows orange for footprint added to cart

**Test `Add all to cart` button**
- load app
- search
- click on scene so that more than one scene is clicked
- click `Add all to cart` button 
- confirm `Add all to cart` button is no longer clickable
- confirm cart button in top search bar reflects total number of scenes added
- confirm summary text in top of popup shows '({ total number of scenes} in cart)'
- confirm legend shows 'Scenes in cart' symbology
- confirm map outline shows orange for all footprints added to cart
- confirm bottom button text changes to say 'Remove scene from cart'
- click the next arrow in the lower left of the popup
- confirm bottom button text still says 'Remove scene from cart'
- while on second page, click 'Remove scene from cart' button
- confirm 'Add all to cart' button gets enabled again
- click 'Add all to cart' button again
- confirm cart only gets increased by one (so only those not already in cart get added)
- confirm 'Add all to cart' button gets disabled again

**Test BONUS 1: minimize popup result**
- load app
- search
- click on scene(s)
- click the down arrow button in the top right of the popup result
- confirm single result details no longer renders
- confirm 'Add scene to cart' button no longer renders
- confirm 'Add all to cart' button still renders
- click next arrow in lower right of popup
- confirm map loads image overlay for next scene
- confirm popup result reflects incremented index of selected scene
- click up arrow in top right of popup result
- confirm single result details loads
- confirm single result detail reflects correct currently selected scene/image on map

**Test BONUS 2: persisted cart map layer**
- load app
- search (make note of starting collection and search date range)
- click on scene(s)
- click 'Add all to cart' button
- confirm orange map footprints get added
- click close 'X' button in top right of popup results
- confirm orange map footprints still show on map after popup is closed
- change collection
- confirm orange map footprints still show on map
- search in new collection
- confirm orange map footprints still show on map
- change collections and zoom levels to view grid aggregations and hex aggregations
- confirm orange map footprints still show on map
- change back to original collection 
- change back to original date range
- click search
- click original scenes selected again
- for each, click 'Remove scene from cart'
- confirm orange map footprints no longer show on map

**PR Checklist:**

- [X] I have added my changes to the [CHANGELOG](https://github.com/Element84/filmdrop-ui/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
