### PR TITLE
Ba/feature/add cart buttons to count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Added
+
+- Add buttons for: `loading all scenes` and `selecting all scenes on map` to show in popup if more than initial load of 200 scenes is matched.
+
+### Changed
+
+- Migrate vitest coverage provider to use v8 instead of c8.
+
 ## 3.3.0 - 2023-08-17
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "@types/vite-plugin-react-svg": "^0.2.2",
         "@typescript-eslint/eslint-plugin": "^5.59.5",
         "@typescript-eslint/parser": "^5.62.0",
-        "@vitest/coverage-c8": "^0.33.0",
+        "@vitest/coverage-v8": "^0.34.2",
         "better-npm-audit": "^3.7.3",
         "eslint": "^8.44.0",
         "eslint-config-prettier": "^8.8.0",
@@ -2885,23 +2885,29 @@
         "vite": "^4.2.0"
       }
     },
-    "node_modules/@vitest/coverage-c8": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-c8/-/coverage-c8-0.33.0.tgz",
-      "integrity": "sha512-DaF1zJz4dcOZS4k/neiQJokmOWqsGXwhthfmUdPGorXIQHjdPvV6JQSYhQDI41MyI8c+IieQUdIDs5XAMHtDDw==",
+    "node_modules/@vitest/coverage-v8": {
+      "version": "0.34.2",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-0.34.2.tgz",
+      "integrity": "sha512-3VuDZPeGGd1zWtc0Tdj9cHSbFc8IQ0ffnWp9MlhItOkziN6HEf219meZ9cZheg/hJXrXb+Fi2bMu7GeCAfL4yA==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.1",
-        "c8": "^7.14.0",
+        "@bcoe/v8-coverage": "^0.2.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^4.0.1",
+        "istanbul-reports": "^3.1.5",
         "magic-string": "^0.30.1",
         "picocolors": "^1.0.0",
-        "std-env": "^3.3.3"
+        "std-env": "^3.3.3",
+        "test-exclude": "^6.0.0",
+        "v8-to-istanbul": "^9.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "vitest": ">=0.30.0 <1"
+        "vitest": ">=0.32.0 <1"
       }
     },
     "node_modules/@vitest/expect": {
@@ -3537,32 +3543,6 @@
         "semver": "^7.0.0"
       }
     },
-    "node_modules/c8": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/c8/-/c8-7.14.0.tgz",
-      "integrity": "sha512-i04rtkkcNcCf7zsQcSv/T9EbUn4RXQ6mropeMcjFOsQXQ0iGLAr/xT6TImQg4+U9hmNpN9XdvPkjUL1IzbgxJw==",
-      "dev": true,
-      "dependencies": {
-        "@bcoe/v8-coverage": "^0.2.3",
-        "@istanbuljs/schema": "^0.1.3",
-        "find-up": "^5.0.0",
-        "foreground-child": "^2.0.0",
-        "istanbul-lib-coverage": "^3.2.0",
-        "istanbul-lib-report": "^3.0.0",
-        "istanbul-reports": "^3.1.4",
-        "rimraf": "^3.0.2",
-        "test-exclude": "^6.0.0",
-        "v8-to-istanbul": "^9.0.0",
-        "yargs": "^16.2.0",
-        "yargs-parser": "^20.2.9"
-      },
-      "bin": {
-        "c8": "bin/c8.js"
-      },
-      "engines": {
-        "node": ">=10.12.0"
-      }
-    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -3763,17 +3743,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
       "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
-    },
-    "node_modules/cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-      "dev": true,
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
-      }
     },
     "node_modules/clsx": {
       "version": "1.2.1",
@@ -5366,19 +5335,6 @@
         "is-callable": "^1.1.3"
       }
     },
-    "node_modules/foreground-child": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
-      "integrity": "sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==",
-      "dev": true,
-      "dependencies": {
-        "cross-spawn": "^7.0.0",
-        "signal-exit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/form-data": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
@@ -6340,6 +6296,29 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/istanbul-reports": {
@@ -10803,12 +10782,6 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true
     },
-    "node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true
-    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -12494,23 +12467,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
     "node_modules/wrap-ansi-cjs": {
       "name": "wrap-ansi",
       "version": "7.0.0",
@@ -12571,15 +12527,6 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
     },
-    "node_modules/y18n": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -12591,33 +12538,6 @@
       "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-      "dev": true,
-      "dependencies": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/yocto-queue": {
@@ -14515,17 +14435,23 @@
         "react-refresh": "^0.14.0"
       }
     },
-    "@vitest/coverage-c8": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-c8/-/coverage-c8-0.33.0.tgz",
-      "integrity": "sha512-DaF1zJz4dcOZS4k/neiQJokmOWqsGXwhthfmUdPGorXIQHjdPvV6JQSYhQDI41MyI8c+IieQUdIDs5XAMHtDDw==",
+    "@vitest/coverage-v8": {
+      "version": "0.34.2",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-0.34.2.tgz",
+      "integrity": "sha512-3VuDZPeGGd1zWtc0Tdj9cHSbFc8IQ0ffnWp9MlhItOkziN6HEf219meZ9cZheg/hJXrXb+Fi2bMu7GeCAfL4yA==",
       "dev": true,
       "requires": {
         "@ampproject/remapping": "^2.2.1",
-        "c8": "^7.14.0",
+        "@bcoe/v8-coverage": "^0.2.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^4.0.1",
+        "istanbul-reports": "^3.1.5",
         "magic-string": "^0.30.1",
         "picocolors": "^1.0.0",
-        "std-env": "^3.3.3"
+        "std-env": "^3.3.3",
+        "test-exclude": "^6.0.0",
+        "v8-to-istanbul": "^9.1.0"
       }
     },
     "@vitest/expect": {
@@ -14981,26 +14907,6 @@
         "semver": "^7.5.3"
       }
     },
-    "c8": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/c8/-/c8-7.14.0.tgz",
-      "integrity": "sha512-i04rtkkcNcCf7zsQcSv/T9EbUn4RXQ6mropeMcjFOsQXQ0iGLAr/xT6TImQg4+U9hmNpN9XdvPkjUL1IzbgxJw==",
-      "dev": true,
-      "requires": {
-        "@bcoe/v8-coverage": "^0.2.3",
-        "@istanbuljs/schema": "^0.1.3",
-        "find-up": "^5.0.0",
-        "foreground-child": "^2.0.0",
-        "istanbul-lib-coverage": "^3.2.0",
-        "istanbul-lib-report": "^3.0.0",
-        "istanbul-reports": "^3.1.4",
-        "rimraf": "^3.0.2",
-        "test-exclude": "^6.0.0",
-        "v8-to-istanbul": "^9.0.0",
-        "yargs": "^16.2.0",
-        "yargs-parser": "^20.2.9"
-      }
-    },
     "cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -15125,17 +15031,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
       "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
-    },
-    "cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-      "dev": true,
-      "requires": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
-      }
     },
     "clsx": {
       "version": "1.2.1",
@@ -16253,16 +16148,6 @@
         "is-callable": "^1.1.3"
       }
     },
-    "foreground-child": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
-      "integrity": "sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==",
-      "dev": true,
-      "requires": {
-        "cross-spawn": "^7.0.0",
-        "signal-exit": "^3.0.2"
-      }
-    },
     "form-data": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
@@ -16932,6 +16817,25 @@
         "istanbul-lib-coverage": "^3.0.0",
         "make-dir": "^4.0.0",
         "supports-color": "^7.1.0"
+      }
+    },
+    "istanbul-lib-source-maps": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
       }
     },
     "istanbul-reports": {
@@ -20169,12 +20073,6 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true
     },
-    "signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true
-    },
     "slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -21364,17 +21262,6 @@
         "stackback": "0.0.2"
       }
     },
-    "wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "requires": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      }
-    },
     "wrap-ansi-cjs": {
       "version": "npm:wrap-ansi@7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -21411,12 +21298,6 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
     },
-    "y18n": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true
-    },
     "yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -21426,27 +21307,6 @@
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
       "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
-    },
-    "yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-      "dev": true,
-      "requires": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
-      }
-    },
-    "yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-      "dev": true
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@types/vite-plugin-react-svg": "^0.2.2",
     "@typescript-eslint/eslint-plugin": "^5.59.5",
     "@typescript-eslint/parser": "^5.62.0",
-    "@vitest/coverage-c8": "^0.33.0",
+    "@vitest/coverage-v8": "^0.34.2",
     "better-npm-audit": "^3.7.3",
     "eslint": "^8.44.0",
     "eslint-config-prettier": "^8.8.0",

--- a/src/components/DateTimeRangeSelector/DateTimeRangeSelector.jsx
+++ b/src/components/DateTimeRangeSelector/DateTimeRangeSelector.jsx
@@ -120,7 +120,7 @@ const DateTimeRangeSelector = () => {
       <DateTimeRangePicker
         className="dateTimePicker"
         format={'yy-MM-dd'}
-        calendarType="US"
+        calendarType="gregory"
         showLeadingZeros={false}
         disableClock={true}
         required={true}

--- a/src/components/Layout/Content/BottomContent/BottomContent.css
+++ b/src/components/Layout/Content/BottomContent/BottomContent.css
@@ -120,7 +120,7 @@
   flex-direction: row;
 }
 
-.resultCountButtons button {
+.countButton {
   background-color: transparent;
   color: #a9b0c1;
   border: 1px solid #a9b0c1;
@@ -128,6 +128,7 @@
   height: 32px;
   font-size: 16px;
   display: flex;
+  flex-direction: row;
   align-items: center;
   justify-content: center;
   cursor: pointer;
@@ -137,9 +138,23 @@
   user-select: none;
   margin-left: 10px;
 }
-.resultCountButtons button:hover {
+.countButton:hover {
   background-color: #252f36;
   color: #fff;
+}
+
+.disabledCountButton {
+  color: #7f828a;
+  border: 1px solid #7f828a;
+  cursor: default;
+}
+.disabledCountButton:hover {
+  color: #7f828a;
+  background-color: transparent;
+}
+
+.countButtonCancelText {
+  margin-right: 10px;
 }
 
 .drawGeomMessage {
@@ -234,7 +249,6 @@
   }
 
   .resultCount {
-    width: 70%;
     left: 52px;
     transform: none;
   }

--- a/src/components/Layout/Content/BottomContent/BottomContent.css
+++ b/src/components/Layout/Content/BottomContent/BottomContent.css
@@ -92,7 +92,7 @@
   left: 50%;
   transform: translateX(-50%);
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   background-color: rgba(34, 34, 34, 0.8);
   padding: 10px 20px;
   border-radius: 5px;
@@ -101,6 +101,45 @@
   font-size: 0.75em;
   letter-spacing: 0.025em;
   line-height: 1.8;
+}
+
+.resultCountText {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.resultCountCartText {
+  display: flex;
+  flex-direction: column;
+}
+
+.resultCountButtons {
+  margin-left: 10px;
+  display: flex;
+  flex-direction: row;
+}
+
+.resultCountButtons button {
+  background-color: transparent;
+  color: #a9b0c1;
+  border: 1px solid #a9b0c1;
+  border-radius: 5px;
+  height: 32px;
+  font-size: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: color 0.33s ease-in-out;
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  user-select: none;
+  margin-left: 10px;
+}
+.resultCountButtons button:hover {
+  background-color: #252f36;
+  color: #fff;
 }
 
 .drawGeomMessage {

--- a/src/components/Layout/Content/BottomContent/BottomContent.jsx
+++ b/src/components/Layout/Content/BottomContent/BottomContent.jsx
@@ -150,7 +150,7 @@ const BottomContent = () => {
             Analyze
           </button>
         )}
-        {_appConfig.SHOW_PUBLISH_BTN === true && (
+        {_appConfig.SHOW_PUBLISH_BTN && (
           <button className="actionButton" onClick={() => onPublishClick()}>
             Publish
           </button>
@@ -251,17 +251,26 @@ const BottomContent = () => {
         <PopupResults results={_clickResults}></PopupResults>
       ) : null}
       {_searchLoading ? (
-        <div className="loadingSpinnerContainer">
+        <div
+          className="loadingSpinnerContainer"
+          data-testid="testsearchLoadingAnimation"
+        >
           <LoadingAnimation></LoadingAnimation>
         </div>
       ) : null}
       {_imageOverlayLoading ? (
-        <div className="loadingSpinnerContainer">
+        <div
+          className="loadingSpinnerContainer"
+          data-testid="test_imageOverlayLoadingAnimation"
+        >
           <LoadingAnimation></LoadingAnimation>
         </div>
       ) : null}
       {_showAppLoading && (
-        <div className="appLoadingContainer">
+        <div
+          className="appLoadingContainer"
+          data-testid="test_applicationLoadingAnimation"
+        >
           <LoadingAnimation></LoadingAnimation>
           <span>Loading {DEFAULT_APP_NAME}</span>
         </div>

--- a/src/components/Layout/Content/BottomContent/BottomContent.jsx
+++ b/src/components/Layout/Content/BottomContent/BottomContent.jsx
@@ -26,7 +26,6 @@ import { CircularProgress } from '@mui/material'
 
 const BottomContent = () => {
   const [allScenesLoading, setallScenesLoading] = useState(false)
-  const _map = useSelector((state) => state.mainSlice.map)
   const _showAppLoading = useSelector((state) => state.mainSlice.showAppLoading)
   const _searchResults = useSelector((state) => state.mainSlice.searchResults)
   const _clickResults = useSelector((state) => state.mainSlice.clickResults)
@@ -78,7 +77,6 @@ const BottomContent = () => {
     if (_viewMode === 'mosaic') {
       const MOSAIC_MIN_ZOOM =
         _appConfig.MOSAIC_MIN_ZOOM_LEVEL || DEFAULT_MOSAIC_MIN_ZOOM
-      _map.setZoom(MOSAIC_MIN_ZOOM)
       setMapZoomLevel(MOSAIC_MIN_ZOOM)
       dispatch(setShowZoomNotice(false))
     } else if (_zoomLevelNeeded) {

--- a/src/components/Layout/Content/BottomContent/BottomContent.jsx
+++ b/src/components/Layout/Content/BottomContent/BottomContent.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react'
+import React, { useState, useRef } from 'react'
 import './BottomContent.css'
 import { DEFAULT_MOSAIC_MIN_ZOOM, DEFAULT_APP_NAME } from '../../../defaults'
 import LeafMap from '../../../LeafMap/LeafMap'

--- a/src/components/Layout/Content/BottomContent/BottomContent.test.jsx
+++ b/src/components/Layout/Content/BottomContent/BottomContent.test.jsx
@@ -1,4 +1,4 @@
-import { vi } from 'vitest'
+import { describe, vi } from 'vitest'
 import React from 'react'
 import { render, screen } from '@testing-library/react'
 import BottomContent from './BottomContent'
@@ -14,13 +14,19 @@ import {
   setimageOverlayLoading,
   setShowAppLoading,
   setSearchLoading,
-  setShowZoomNotice
+  setShowZoomNotice,
+  setShowPopupModal,
+  setClickResults,
+  setZoomLevelNeeded,
+  setViewMode,
+  setmappedScenes
 } from '../../../../redux/slices/mainSlice'
 import {
   mockSceneSearchResult,
   mockHexAggregateSearchResult,
   mockGridAggregateSearchResult,
-  mockAppConfig
+  mockAppConfig,
+  mockClickResults
 } from '../../../../testing/shared-mocks'
 import userEvent from '@testing-library/user-event'
 import * as mapHelper from '../../../../utils/mapHelper'
@@ -206,6 +212,23 @@ describe('BottomContent', () => {
         screen.queryByText(/images are not visible at this zoom level\./i)
       ).not.toBeInTheDocument()
     })
+    it('should render popup results if showPopupModal set to true in redux and clickResults greater than 0', () => {
+      store.dispatch(setShowPopupModal(true))
+      store.dispatch(setClickResults([mockClickResults[0]]))
+      setup()
+      expect(screen.queryByTestId('testPopupResults')).toBeInTheDocument()
+    })
+    it('should not render popup results if showPopupModal set to false in redux', () => {
+      store.dispatch(setClickResults([mockClickResults[0]]))
+      setup()
+      expect(screen.queryByTestId('testPopupResults')).not.toBeInTheDocument()
+    })
+    it('should not render popup results clickResults has not results added', () => {
+      store.dispatch(setShowPopupModal(true))
+      store.dispatch(setClickResults([]))
+      setup()
+      expect(screen.queryByTestId('testPopupResults')).not.toBeInTheDocument()
+    })
   })
   describe('when isDrawingEnabled is true', () => {
     beforeEach(() => {
@@ -274,6 +297,113 @@ describe('BottomContent', () => {
       expect(
         screen.queryByTestId('testShowingAggregatedMessage')
       ).toBeInTheDocument()
+    })
+  })
+  describe('on button clicks', () => {
+    describe('on analyze clicked', () => {
+      it('should open a new window with analyze URL', async () => {
+        window.open = vi.fn()
+        const openSpy = vi.spyOn(window, 'open')
+        const mockAnalyzeBtnUrl = 'https://example.com/analyze'
+        const mockAppConfigSearchEnabled = {
+          ...mockAppConfig,
+          ANALYZE_BTN_URL: mockAnalyzeBtnUrl
+        }
+        store.dispatch(setappConfig(mockAppConfigSearchEnabled))
+        setup()
+        const analyzeButton = screen.getByRole('button', {
+          name: /analyze/i
+        })
+        await user.click(analyzeButton)
+        expect(openSpy).toHaveBeenCalledWith(mockAnalyzeBtnUrl, '_blank')
+      })
+    })
+    describe('on launch clicked', () => {
+      it('should open a new window with launch URL', async () => {
+        window.open = vi.fn()
+        const openSpy = vi.spyOn(window, 'open')
+        const mockLaunchBtnUrl = 'https://example.com/launch'
+        const mockAppConfigSearchEnabled = {
+          ...mockAppConfig,
+          LAUNCH_URL: mockLaunchBtnUrl
+        }
+        store.dispatch(setappConfig(mockAppConfigSearchEnabled))
+        setup()
+        const launchButton = screen.getByRole('button', {
+          name: /launch your own/i
+        })
+        await user.click(launchButton)
+        expect(openSpy).toHaveBeenCalledWith(mockLaunchBtnUrl, '_blank')
+      })
+    })
+    describe('on publish clicked', () => {
+      it('should show publish modal', async () => {
+        const mockAppConfigSearchEnabled = {
+          ...mockAppConfig,
+          SHOW_PUBLISH_BTN: true
+        }
+        store.dispatch(setappConfig(mockAppConfigSearchEnabled))
+        setup()
+        const publishButton = screen.getByRole('button', {
+          name: /publish/i
+        })
+        await user.click(publishButton)
+        expect(store.getState().mainSlice.showPublishModal).toBeTruthy()
+      })
+    })
+    describe('on zoom Clicked', () => {
+      it('should zoom in to match the redux zoom level if view mode is not mosaic', async () => {
+        store.dispatch(setShowZoomNotice(true))
+        store.dispatch(setZoomLevelNeeded(7))
+        const zoomSpy = vi.spyOn(mapHelper, 'setMapZoomLevel')
+        setup()
+        const zoomButton = screen.getByText(/zoom in/i)
+        await user.click(zoomButton)
+        expect(zoomSpy).toHaveBeenCalledWith(7)
+      })
+      it('should zoom in to match the config zoom level if view mode is mosaic', async () => {
+        store.dispatch(setShowZoomNotice(true))
+        store.dispatch(setZoomLevelNeeded(7))
+        store.dispatch(setViewMode('mosaic'))
+        const zoomSpy = vi.spyOn(mapHelper, 'setMapZoomLevel')
+        store.dispatch(setappConfig(mockAppConfig))
+        setup()
+        const zoomButton = screen.getByText(/zoom in/i)
+        await user.click(zoomButton)
+        expect(zoomSpy).toHaveBeenCalledWith(7)
+        expect(store.getState().mainSlice.showZoomNotice).toBeFalsy()
+      })
+    })
+    describe('on Cancel Draw Geom clicked', () => {
+      it('should set isDrawingEnabled to false in redux and call disableMapPolyDrawing', async () => {
+        const disableMapPloyDrawingSpy = vi.spyOn(
+          mapHelper,
+          'disableMapPolyDrawing'
+        )
+        store.dispatch(setappConfig(mockAppConfig))
+        store.dispatch(setisDrawingEnabled(true))
+        setup()
+        const cancelButton = screen.getByRole('button', {
+          name: /cancel/i
+        })
+        await user.click(cancelButton)
+        expect(store.getState().mainSlice.isDrawingEnabled).toBeFalsy()
+        expect(disableMapPloyDrawingSpy).toHaveBeenCalledOnce()
+      })
+    })
+    describe('on Select All Scenes clicked', () => {
+      it('should call selectMappedScenes', async () => {
+        const selectMappedScenesSpy = vi.spyOn(mapHelper, 'selectMappedScenes')
+        store.dispatch(setappConfig(mockAppConfig))
+        store.dispatch(setSearchResults(mockSceneSearchResult))
+        store.dispatch(setmappedScenes(mockSceneSearchResult.features))
+        setup()
+        const selectScenesButton = screen.getByRole('button', {
+          name: /select scenes/i
+        })
+        await user.click(selectScenesButton)
+        expect(selectMappedScenesSpy).toHaveBeenCalledOnce()
+      })
     })
   })
 })

--- a/src/components/Layout/Content/BottomContent/BottomContent.test.jsx
+++ b/src/components/Layout/Content/BottomContent/BottomContent.test.jsx
@@ -10,7 +10,11 @@ import {
   setappConfig,
   setsearchGeojsonBoundary,
   setSearchType,
-  setcartItems
+  setcartItems,
+  setimageOverlayLoading,
+  setShowAppLoading,
+  setSearchLoading,
+  setShowZoomNotice
 } from '../../../../redux/slices/mainSlice'
 import {
   mockSceneSearchResult,
@@ -92,8 +96,117 @@ describe('BottomContent', () => {
       setup()
       expect(screen.queryByTestId('testLayerLegend')).not.toBeInTheDocument()
     })
+    it('should render loading animation when searchLoading is true', async () => {
+      store.dispatch(setSearchLoading(true))
+      store.dispatch(setappConfig(mockAppConfig))
+      setup()
+      expect(
+        screen.queryByTestId('testsearchLoadingAnimation')
+      ).toBeInTheDocument()
+    })
+    it('should not render loading animation when searchLoading is false', async () => {
+      store.dispatch(setSearchLoading(false))
+      store.dispatch(setappConfig(mockAppConfig))
+      setup()
+      expect(
+        screen.queryByTestId('testsearchLoadingAnimation')
+      ).not.toBeInTheDocument()
+    })
+    it('should render loading animation when imageOverlay loading is true', async () => {
+      store.dispatch(setimageOverlayLoading(true))
+      store.dispatch(setappConfig(mockAppConfig))
+      setup()
+      expect(
+        screen.queryByTestId('test_imageOverlayLoadingAnimation')
+      ).toBeInTheDocument()
+    })
+    it('should not render loading animation when imageOverlay loading is false', async () => {
+      store.dispatch(setimageOverlayLoading(false))
+      store.dispatch(setappConfig(mockAppConfig))
+      setup()
+      expect(
+        screen.queryByTestId('test_imageOverlayLoadingAnimation')
+      ).not.toBeInTheDocument()
+    })
+    it('should render application loading animation when showAppLoading loading is true', async () => {
+      store.dispatch(setShowAppLoading(true))
+      vi.mock('../../../defaults.js', () => ({
+        DEFAULT_APP_NAME: 'test app'
+      }))
+      setup()
+      expect(
+        screen.queryByTestId('test_applicationLoadingAnimation')
+      ).toBeInTheDocument()
+      expect(screen.queryByText(/loading test app/i)).toBeInTheDocument()
+    })
+    it('should not render application loading animation when showAppLoading loading is false', async () => {
+      store.dispatch(setappConfig(mockAppConfig))
+      store.dispatch(setShowAppLoading(false))
+      vi.mock('../../../defaults.js', () => ({
+        DEFAULT_APP_NAME: 'test app'
+      }))
+      setup()
+      expect(
+        screen.queryByTestId('test_applicationLoadingAnimation')
+      ).not.toBeInTheDocument()
+      expect(screen.queryByText(/loading test app/i)).not.toBeInTheDocument()
+    })
+    it('should render publish Button if SHOW_PUBLISH_BTN set in config', () => {
+      const mockAppConfigSearchEnabled = {
+        ...mockAppConfig,
+        SHOW_PUBLISH_BTN: true
+      }
+      store.dispatch(setappConfig(mockAppConfigSearchEnabled))
+      setup()
+      expect(
+        screen.queryByRole('button', {
+          name: /publish/i
+        })
+      ).toBeInTheDocument()
+    })
+    it('should not render publish Button if SHOW_PUBLISH_BTN not set in config', () => {
+      setup()
+      expect(
+        screen.queryByRole('button', {
+          name: /publish/i
+        })
+      ).not.toBeInTheDocument()
+    })
+    it('should render analyze Button if ANALYZE_BTN_URL set in config', () => {
+      setup()
+      expect(
+        screen.queryByRole('button', {
+          name: /analyze/i
+        })
+      ).toBeInTheDocument()
+    })
+    it('should not render analyze Button if ANALYZE_BTN_URL not set in config', () => {
+      const mockAppConfigSearchEnabled = {
+        ...mockAppConfig,
+        ANALYZE_BTN_URL: ''
+      }
+      store.dispatch(setappConfig(mockAppConfigSearchEnabled))
+      setup()
+      expect(
+        screen.queryByRole('button', {
+          name: /analyze/i
+        })
+      ).not.toBeInTheDocument()
+    })
+    it('should render zoom notice if showZoomNotice set to true in redux', () => {
+      store.dispatch(setShowZoomNotice(true))
+      setup()
+      expect(
+        screen.queryByText(/images are not visible at this zoom level\./i)
+      ).toBeInTheDocument()
+    })
+    it('should not render  zoom notice if showZoomNotice set to false in redux', () => {
+      setup()
+      expect(
+        screen.queryByText(/images are not visible at this zoom level\./i)
+      ).not.toBeInTheDocument()
+    })
   })
-
   describe('when isDrawingEnabled is true', () => {
     beforeEach(() => {
       store.dispatch(setisDrawingEnabled(true))

--- a/src/components/PopupResults/PopupResults.jsx
+++ b/src/components/PopupResults/PopupResults.jsx
@@ -11,7 +11,7 @@ import {
   setShowPopupModal,
   setCurrentPopupResult,
   setcartItems,
-  setSearchLoading
+  setimageOverlayLoading
 } from '../../redux/slices/mainSlice'
 import { ChevronRight, ChevronLeft } from '@mui/icons-material'
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown'
@@ -38,7 +38,7 @@ const PopupResults = (props) => {
     dispatch(setCurrentPopupResult(props.results[currentResultIndex]))
     debounceTitilerOverlay()
     return () => {
-      dispatch(setSearchLoading(false))
+      dispatch(setimageOverlayLoading(false))
     }
   }, [currentResultIndex, props.results])
 
@@ -60,7 +60,7 @@ const PopupResults = (props) => {
 
   function onCloseClick() {
     clearMapSelection()
-    dispatch(setSearchLoading(false))
+    dispatch(setimageOverlayLoading(false))
     dispatch(setShowPopupModal(false))
   }
 

--- a/src/components/PopupResults/PopupResults.test.jsx
+++ b/src/components/PopupResults/PopupResults.test.jsx
@@ -6,7 +6,8 @@ import { store } from '../../redux/store'
 import {
   setShowPopupModal,
   setappConfig,
-  setcartItems
+  setcartItems,
+  setimageOverlayLoading
 } from '../../redux/slices/mainSlice'
 import { mockAppConfig, mockClickResults } from '../../testing/shared-mocks'
 import { describe } from 'vitest'
@@ -151,6 +152,14 @@ describe('PopupResult', () => {
         expect(store.getState().mainSlice.showPopupModal).toBeTruthy()
         fireEvent.click(screen.getByTestId('CloseIcon'))
         expect(store.getState().mainSlice.showPopupModal).toBeFalsy()
+      })
+      it('should set imageOverlayLoading in redux to be false', () => {
+        store.dispatch(setappConfig(mockAppConfig))
+        store.dispatch(setimageOverlayLoading(true))
+        setup()
+        expect(store.getState().mainSlice.imageOverlayLoading).toBeTruthy()
+        fireEvent.click(screen.getByTestId('CloseIcon'))
+        expect(store.getState().mainSlice.imageOverlayLoading).toBeFalsy()
       })
     })
     describe('on Add all to cart button clicked', () => {

--- a/src/components/Search/Search.jsx
+++ b/src/components/Search/Search.jsx
@@ -45,6 +45,7 @@ const Search = () => {
   )
   const _appConfig = useSelector((state) => state.mainSlice.appConfig)
   const _cartItems = useSelector((state) => state.mainSlice.cartItems)
+  const _searchLoading = useSelector((state) => state.mainSlice.searchLoading)
   const mosaicTilerURL = _appConfig.MOSAIC_TILER_URL || ''
 
   useEffect(() => {
@@ -261,6 +262,12 @@ const Search = () => {
         ) : null}
       </div>
       {_isDrawingEnabled ? (
+        <div
+          className="disableSearchOverlay"
+          data-testid="test_disableSearchOverlay"
+        ></div>
+      ) : null}
+      {_searchLoading ? (
         <div
           className="disableSearchOverlay"
           data-testid="test_disableSearchOverlay"

--- a/src/components/Search/Search.test.jsx
+++ b/src/components/Search/Search.test.jsx
@@ -9,7 +9,8 @@ import {
   setcartItems,
   setCloudCover,
   setsearchGeojsonBoundary,
-  setshowAdvancedSearchOptions
+  setshowAdvancedSearchOptions,
+  setSearchLoading
 } from '../../redux/slices/mainSlice'
 import { mockAppConfig } from '../../testing/shared-mocks'
 import userEvent from '@testing-library/user-event'
@@ -277,6 +278,16 @@ describe('Search', () => {
           expect(screen.getByTestId('testCartCount').innerHTML).toBe('1')
         })
       })
+    })
+  })
+  describe('when search loading', () => {
+    it('should render disabled search bar overlay div', async () => {
+      store.dispatch(setSearchLoading(true))
+      store.dispatch(setappConfig(mockAppConfig))
+      setup()
+      expect(
+        screen.queryByTestId('test_disableSearchOverlay')
+      ).toBeInTheDocument()
     })
   })
 })

--- a/src/redux/slices/mainSlice.js
+++ b/src/redux/slices/mainSlice.js
@@ -35,7 +35,8 @@ const initialState = {
   appConfig: null,
   cartItems: [],
   showCartModal: false,
-  mappedScenes: []
+  mappedScenes: [],
+  imageOverlayLoading: false
 }
 
 // next, for every key in the initialState
@@ -145,6 +146,9 @@ export const mainSlice = createSlice({
     },
     setmappedScenes: (state, action) => {
       state.mappedScenes = action.payload
+    },
+    setimageOverlayLoading: (state, action) => {
+      state.imageOverlayLoading = action.payload
     }
   }
 })
@@ -185,5 +189,6 @@ export const { setappConfig } = mainSlice.actions
 export const { setcartItems } = mainSlice.actions
 export const { setshowCartModal } = mainSlice.actions
 export const { setmappedScenes } = mainSlice.actions
+export const { setimageOverlayLoading } = mainSlice.actions
 
 export default mainSlice.reducer

--- a/src/redux/slices/mainSlice.js
+++ b/src/redux/slices/mainSlice.js
@@ -34,7 +34,8 @@ const initialState = {
   applicationAlertSeverity: 'error',
   appConfig: null,
   cartItems: [],
-  showCartModal: false
+  showCartModal: false,
+  mappedScenes: []
 }
 
 // next, for every key in the initialState
@@ -141,6 +142,9 @@ export const mainSlice = createSlice({
     },
     setshowCartModal: (state, action) => {
       state.showCartModal = action.payload
+    },
+    setmappedScenes: (state, action) => {
+      state.mappedScenes = action.payload
     }
   }
 })
@@ -180,5 +184,6 @@ export const { setapplicationAlertSeverity } = mainSlice.actions
 export const { setappConfig } = mainSlice.actions
 export const { setcartItems } = mainSlice.actions
 export const { setshowCartModal } = mainSlice.actions
+export const { setmappedScenes } = mainSlice.actions
 
 export default mainSlice.reducer

--- a/src/services/get-aggregate-service.js
+++ b/src/services/get-aggregate-service.js
@@ -50,7 +50,7 @@ export async function AggregateSearchService(searchParams, gridType) {
       }
 
       store.dispatch(setSearchLoading(false))
-      addDataToLayer(gridFromJson, 'searchResultsLayer', options)
+      addDataToLayer(gridFromJson, 'searchResultsLayer', options, true)
     })
     .catch((error) => {
       store.dispatch(setSearchLoading(false))

--- a/src/services/get-all-scenes-service.js
+++ b/src/services/get-all-scenes-service.js
@@ -1,57 +1,18 @@
 import { store } from '../redux/store'
 import { setmappedScenes } from '../redux/slices/mainSlice'
-import { addDataToLayer, footprintLayerStyle } from '../utils/mapHelper'
-
-// export async function FetchAllScenesService(searchParams, typeOfSearch) {
-//   await fetch(
-//     `${
-//       store.getState().mainSlice.appConfig.STAC_API_URL
-//     }/search?${searchParams}`,
-//     {
-//       method: 'GET'
-//     }
-//   )
-//     .then((response) => {
-//       if (response.ok) {
-//         return response.json()
-//       }
-//       throw new Error()
-//     })
-//     .then((json) => {
-//       if (typeOfSearch === 'scene') {
-//         store.dispatch(setSearchResults(json))
-//         console.log(json.links[0].href)
-//         const options = {
-//           style: footprintLayerStyle
-//         }
-//         store.dispatch(setSearchLoading(false))
-//         addDataToLayer(json, 'searchResultsLayer', options)
-//       } else {
-//         store.dispatch(setSearchLoading(false))
-//         store.dispatch(setClickResults(json.features))
-//         store.dispatch(setShowPopupModal(true))
-//       }
-//     })
-//     .catch((error) => {
-//       store.dispatch(setSearchLoading(false))
-//       const message = 'Error Fetching All Search Results'
-//       // log full error for diagnosing client side errors if needed
-//       console.error(message, error)
-//     })
-// }
-
-// const apiUrl =
-//   'https://earth-search.aws.element84.com/v1/search?datetime=2020-08-01T00%3A00%3A00Z%2F2023-08-15T23%3A59%3A59.999Z&limit=200&collections=sentinel-2-l2a&bbox=-80.68634033203126,37.05956083025126,-75.41290283203126,37.88569271818349&query=%7B%22eo%3Acloud_cover%22%3A%7B%22gte%22%3A0%2C%22lte%22%3A30%7D%7D'
+import {
+  addDataToLayer,
+  footprintLayerStyle,
+  clearLayer
+} from '../utils/mapHelper'
 
 async function fetchFeatures(url, abortSignal) {
   const response = await fetch(url, { signal: abortSignal })
   const data = await response.json()
-
-  // if mappedScenes >= 1000, return
+  clearLayer('clickedSceneImageLayer')
 
   const features = data.features || []
 
-  console.log('Fetched features:', features)
   const options = {
     style: footprintLayerStyle
   }
@@ -60,17 +21,16 @@ async function fetchFeatures(url, abortSignal) {
   store.dispatch(
     setmappedScenes(store.getState().mainSlice.mappedScenes.concat(features))
   )
-  console.log('total feched:', store.getState().mainSlice.mappedScenes.length)
 
   const nextPageLink = data.links.find((link) => link.rel === 'next')
   if (nextPageLink) {
     if (!abortSignal.aborted) {
       if (store.getState().mainSlice.mappedScenes.length >= 1000) {
+        // change this number to increase max number of scenes returned, set to 1000 currently
         return
       }
       const nextFeatures = await fetchFeatures(nextPageLink.href, abortSignal)
       return features.concat(nextFeatures)
-      // push to mappedScenes array
     }
   }
 }
@@ -78,10 +38,3 @@ async function fetchFeatures(url, abortSignal) {
 export async function fetchAllFeatures(url, abortSignal) {
   return await fetchFeatures(url, abortSignal)
 }
-
-// const apiUrl = "https://earth-search.aws.element84.com/v1/search?datetime=2023-08-01T00%3A00%3A00Z%2F2023-08-15T23%3A59%3A59.999Z&limit=200&collections=sentinel-2-l2a&bbox=-80.68634033203126,37.05956083025126,-75.41290283203126,37.88569271818349&query=%7B%22eo%3Acloud_cover%22%3A%7B%22gte%22%3A0%2C%22lte%22%3A30%7D%7D";
-
-// Example of canceling the fetch after 5 seconds (you can replace this with a user interaction)
-// setTimeout(() => {
-
-// }, 5000);

--- a/src/services/get-all-scenes-service.js
+++ b/src/services/get-all-scenes-service.js
@@ -1,0 +1,87 @@
+import { store } from '../redux/store'
+import { setmappedScenes } from '../redux/slices/mainSlice'
+import { addDataToLayer, footprintLayerStyle } from '../utils/mapHelper'
+
+// export async function FetchAllScenesService(searchParams, typeOfSearch) {
+//   await fetch(
+//     `${
+//       store.getState().mainSlice.appConfig.STAC_API_URL
+//     }/search?${searchParams}`,
+//     {
+//       method: 'GET'
+//     }
+//   )
+//     .then((response) => {
+//       if (response.ok) {
+//         return response.json()
+//       }
+//       throw new Error()
+//     })
+//     .then((json) => {
+//       if (typeOfSearch === 'scene') {
+//         store.dispatch(setSearchResults(json))
+//         console.log(json.links[0].href)
+//         const options = {
+//           style: footprintLayerStyle
+//         }
+//         store.dispatch(setSearchLoading(false))
+//         addDataToLayer(json, 'searchResultsLayer', options)
+//       } else {
+//         store.dispatch(setSearchLoading(false))
+//         store.dispatch(setClickResults(json.features))
+//         store.dispatch(setShowPopupModal(true))
+//       }
+//     })
+//     .catch((error) => {
+//       store.dispatch(setSearchLoading(false))
+//       const message = 'Error Fetching All Search Results'
+//       // log full error for diagnosing client side errors if needed
+//       console.error(message, error)
+//     })
+// }
+
+// const apiUrl =
+//   'https://earth-search.aws.element84.com/v1/search?datetime=2020-08-01T00%3A00%3A00Z%2F2023-08-15T23%3A59%3A59.999Z&limit=200&collections=sentinel-2-l2a&bbox=-80.68634033203126,37.05956083025126,-75.41290283203126,37.88569271818349&query=%7B%22eo%3Acloud_cover%22%3A%7B%22gte%22%3A0%2C%22lte%22%3A30%7D%7D'
+
+async function fetchFeatures(url, abortSignal) {
+  const response = await fetch(url, { signal: abortSignal })
+  const data = await response.json()
+
+  // if mappedScenes >= 1000, return
+
+  const features = data.features || []
+
+  console.log('Fetched features:', features)
+  const options = {
+    style: footprintLayerStyle
+  }
+  addDataToLayer(features, 'searchResultsLayer', options, false)
+
+  store.dispatch(
+    setmappedScenes(store.getState().mainSlice.mappedScenes.concat(features))
+  )
+  console.log('total feched:', store.getState().mainSlice.mappedScenes.length)
+
+  const nextPageLink = data.links.find((link) => link.rel === 'next')
+  if (nextPageLink) {
+    if (!abortSignal.aborted) {
+      if (store.getState().mainSlice.mappedScenes.length >= 1000) {
+        return
+      }
+      const nextFeatures = await fetchFeatures(nextPageLink.href, abortSignal)
+      return features.concat(nextFeatures)
+      // push to mappedScenes array
+    }
+  }
+}
+
+export async function fetchAllFeatures(url, abortSignal) {
+  return await fetchFeatures(url, abortSignal)
+}
+
+// const apiUrl = "https://earth-search.aws.element84.com/v1/search?datetime=2023-08-01T00%3A00%3A00Z%2F2023-08-15T23%3A59%3A59.999Z&limit=200&collections=sentinel-2-l2a&bbox=-80.68634033203126,37.05956083025126,-75.41290283203126,37.88569271818349&query=%7B%22eo%3Acloud_cover%22%3A%7B%22gte%22%3A0%2C%22lte%22%3A30%7D%7D";
+
+// Example of canceling the fetch after 5 seconds (you can replace this with a user interaction)
+// setTimeout(() => {
+
+// }, 5000);

--- a/src/services/get-local-grid-data-json-service.js
+++ b/src/services/get-local-grid-data-json-service.js
@@ -1,6 +1,5 @@
 import { store } from '../redux/store'
 import { setLocalGridData } from '../redux/slices/mainSlice'
-// import { addDataToLayer } from '../utils/mapHelper'
 
 export async function LoadLocalGridDataService(fileName) {
   await fetch(`/data/${fileName}.json`, {

--- a/src/services/get-search-service.js
+++ b/src/services/get-search-service.js
@@ -3,7 +3,8 @@ import {
   setClickResults,
   setSearchLoading,
   setSearchResults,
-  setShowPopupModal
+  setShowPopupModal,
+  setmappedScenes
 } from '../redux/slices/mainSlice'
 import { addDataToLayer, footprintLayerStyle } from '../utils/mapHelper'
 
@@ -25,11 +26,13 @@ export async function SearchService(searchParams, typeOfSearch) {
     .then((json) => {
       if (typeOfSearch === 'scene') {
         store.dispatch(setSearchResults(json))
+        store.dispatch(setmappedScenes(json.features))
+        console.log(json.links[0].href)
         const options = {
           style: footprintLayerStyle
         }
         store.dispatch(setSearchLoading(false))
-        addDataToLayer(json, 'searchResultsLayer', options)
+        addDataToLayer(json, 'searchResultsLayer', options, true)
       } else {
         store.dispatch(setSearchLoading(false))
         store.dispatch(setClickResults(json.features))

--- a/src/services/get-search-service.js
+++ b/src/services/get-search-service.js
@@ -27,7 +27,6 @@ export async function SearchService(searchParams, typeOfSearch) {
       if (typeOfSearch === 'scene') {
         store.dispatch(setSearchResults(json))
         store.dispatch(setmappedScenes(json.features))
-        console.log(json.links[0].href)
         const options = {
           style: footprintLayerStyle
         }

--- a/src/utils/dataHelper.js
+++ b/src/utils/dataHelper.js
@@ -67,7 +67,7 @@ export function setScenesForCartLayer() {
     style: cartFootprintLayerStyle,
     interactive: false
   }
-  addDataToLayer(cartGeojson, 'cartFootprintsLayer', options)
+  addDataToLayer(cartGeojson, 'cartFootprintsLayer', options, true)
 }
 
 export function processDisplayFieldValues(value) {

--- a/src/utils/dataHelper.test.js
+++ b/src/utils/dataHelper.test.js
@@ -114,7 +114,8 @@ describe('dataHelper', () => {
           features: mockCartItems
         }),
         'cartFootprintsLayer',
-        expect.any(Object)
+        expect.any(Object),
+        true
       )
     })
   })

--- a/src/utils/mapHelper.js
+++ b/src/utils/mapHelper.js
@@ -85,8 +85,8 @@ export function mapClickHandler(e) {
   const map = store.getState().mainSlice.map
   const clickBounds = L.latLngBounds(e.latlng, e.latlng)
   if (map && Object.keys(map).length > 0) {
-    const _searchResults = store.getState().mainSlice.searchResults
     const _searchType = store.getState().mainSlice.searchType
+    const _mappedScenes = store.getState().mainSlice.mappedScenes
 
     clearMapSelection()
 
@@ -100,9 +100,9 @@ export function mapClickHandler(e) {
 
     // pull all items from search results that intersect with the click bounds
     let intersectingFeatures = []
-    if (_searchResults !== null) {
-      for (const f in _searchResults.features) {
-        const feature = _searchResults.features[f]
+    if (_mappedScenes !== null) {
+      for (const f in _mappedScenes) {
+        const feature = _mappedScenes[f]
         const featureBounds = L.geoJSON(feature).getBounds()
         if (featureBounds && featureBounds.intersects(clickBounds)) {
           // highlight layer
@@ -136,13 +136,36 @@ export function mapClickHandler(e) {
   }
 }
 
+export function selectMappedScenes() {
+  const map = store.getState().mainSlice.map
+  if (map && Object.keys(map).length > 0) {
+    const _mappedScenes = store.getState().mainSlice.mappedScenes
+    store.dispatch(setClickResults(_mappedScenes))
+    // highlight layer
+    for (const f in _mappedScenes) {
+      const feature = _mappedScenes[f]
+      const clickedFootprintsFound = L.geoJSON(feature, {
+        style: clickedFootprintLayerStyle
+      })
+      map.eachLayer(function (layer) {
+        if (layer.layer_name === 'clickedSceneHighlightLayer') {
+          clickedFootprintsFound.addTo(layer)
+        }
+      })
+    }
+    store.dispatch(setShowPopupModal(true))
+  }
+}
+
 // searchResultsLayer | clickedSceneHighlightLayer
-export function addDataToLayer(geojson, layerName, options) {
+export function addDataToLayer(geojson, layerName, options, clearExisting) {
   const map = store.getState().mainSlice.map
   if (map && Object.keys(map).length > 0) {
     map.eachLayer(function (layer) {
       if (layer.layer_name === layerName) {
-        clearLayer(layerName) // clear layer before adding new
+        if (clearExisting) {
+          clearLayer(layerName) // clear layer before adding new
+        }
         if (options !== 'undefined') {
           L.geoJSON(geojson, options).addTo(layer)
         } else {

--- a/src/utils/mapHelper.js
+++ b/src/utils/mapHelper.js
@@ -142,7 +142,6 @@ export function selectMappedScenes() {
   if (map && Object.keys(map).length > 0) {
     const _mappedScenes = store.getState().mainSlice.mappedScenes
     store.dispatch(setClickResults(_mappedScenes))
-    // highlight layer
     for (const f in _mappedScenes) {
       const feature = _mappedScenes[f]
       const clickedFootprintsFound = L.geoJSON(feature, {

--- a/src/utils/mapHelper.js
+++ b/src/utils/mapHelper.js
@@ -6,9 +6,10 @@ import {
   setClickResults,
   setShowPopupModal,
   setShowZoomNotice,
-  setSearchLoading,
   setisDrawingEnabled,
-  setsearchGeojsonBoundary
+  setsearchGeojsonBoundary,
+  setimageOverlayLoading,
+  setSearchLoading
 } from '../redux/slices/mainSlice'
 import { searchGridCodeScenes, debounceNewSearch } from './searchHelper'
 import debounce from './debounce'
@@ -333,7 +334,7 @@ export const debounceTitilerOverlay = debounce(() => addImageOverlay(), 800)
 
 function addImageOverlay() {
   if (!store.getState().mainSlice.currentPopupResult) {
-    store.dispatch(setSearchLoading(false))
+    store.dispatch(setimageOverlayLoading(false))
     return
   }
   const sceneTilerURL =
@@ -343,7 +344,7 @@ function addImageOverlay() {
     store.getState().mainSlice.selectedCollectionData
   // TODO: consider changing how spinner loads, or not at all?
   // maybe load spinner in footprint extent? or different loading spinner?
-  store.dispatch(setSearchLoading(true))
+  store.dispatch(setimageOverlayLoading(true))
 
   clearLayer('clickedSceneImageLayer')
 
@@ -370,10 +371,10 @@ function addImageOverlay() {
             }
           )
             .on('load', function () {
-              store.dispatch(setSearchLoading(false))
+              store.dispatch(setimageOverlayLoading(false))
             })
             .on('tileerror', function () {
-              store.dispatch(setSearchLoading(false))
+              store.dispatch(setimageOverlayLoading(false))
               console.log('Tile Error')
             })
 
@@ -384,7 +385,7 @@ function addImageOverlay() {
           })
         }
       } else {
-        store.dispatch(setSearchLoading(false))
+        store.dispatch(setimageOverlayLoading(false))
       }
     })
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
     setupFiles: ['./src/setupTests.js'],
     threads: false,
     coverage: {
-      provider: 'c8',
+      provider: 'v8',
       reporter: ['text'],
       exclude: [...configDefaults.coverage.exclude, 'src/redux/*'] // ignore the redux boilerplate for coverage report
     }


### PR DESCRIPTION
**Related Issue(s):**

- NA

**Proposed Changes:**

1. Add buttons for: loading all scenes, selecting scenes per mock if more than initial load of 200 scenes 
> NOTE: max scenes added upper limit set to be 1k scenes based on limitations in API & rendering engine - discussed and approved with product owner
2. Add get all scenes service
3. Separate `imageOverlayLoading` state from `SearchLoading` state
4. Add `mappedScenes` to redux state to track all scenes on map not just a single search result
5. Add `clearExisting` param in `addDataToLayer()` function to keep DRY but allow for persisting scenes when adding more to map

Bonus 1: fix log error with update to datetimerange picker from `US` to `gregory`
Bonus 2: Migrate vitest coverage provider to use v8 instead of c8

### To test:

**confirm all automated tests pass** 🍏 `npm run test`

**Test buttons conditional render**
- load app
- click search
- zoom in until individual scenes show on map & senes returned are less than 200
- confirm `Select scenes` button renders in scene count at top center of map
- confirm `Load all scenes` button does not render in scene count at top center of map
- change search filters so that more than 200 scenes are returned

  > easy way to do this is set starting month back a few months
- confirm `Select scenes` and `Load all scenes` buttons render in scene count at top center of map
- zoom out to scene aggregate level for grid (not hex)
- confirm `Select scenes` and `Load all scenes` buttons do not render anymore
- change collection to something that uses hex aggressions (like Cop DEM)
- click search
- confirm `Select scenes` and `Load all scenes` buttons still do not render

**Test selecting scenes**
- load app
- zoom in until individual scenes show on map
- confirm `Select scenes` button shows in scene count at top center of map
- click `Select scenes` button
- confirm all scenes showing on map are selected 
- confirm `Select scenes` button is no longer selectable
- confirm popup result count reflects the number of selected scenes
- use arrow buttons in popup result and confirm connection between mapped scene highlight & overlay and popup result changes
- click 'x' close button in top right of popup result
- confirm popup closes
- confirm all scenes get deselected 

**Test loading all/more scenes**
- load app
- zoom in until individual scenes show on map
- change search filters so that more than 1000 scenes are returned
- click search
- click 'Load all scenes' button
- confirm button text changes to `cancel`
- confirm loading spinner shows next to button
- confirm loading spinner shows over top of map
- confirm footprints clear initially
- confirm footprints start getting re-added to map
- confirm this keeps happening until 1000 scenes get loaded
- confirm button text changes to say `Max scenes loaded`
- click search again
- before all scenes reload, click `cancel` button
- confirm button text changes back to `Load all scenes`
- confirm partially returned search results still persist on the map
- click `Load all scenes` button again
- confirm all scenes get cleared from map and loading all starts over again clean

**Test buttons don't render with autosearch**
- set `ADVANCED_SEARCH_ENABLED` to be `false` in config.json
- load app
- change search filters so that more than 200 scenes are returned
- click search
- zoom in until individual scenes show on map
- confirm `Select scenes` & `Load all scenes` buttons shows in scene count at top center of map
- toggle auto search on in search controls above map
- confirm `Select scenes` & `Load all scenes` buttons no longer render 


**PR Checklist:**

- [X] I have added my changes to the [CHANGELOG](https://github.com/Element84/filmdrop-ui/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
