### PR TITLE
Ba/bug/map attribution show until interaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Migrate vitest coverage provider to use v8 instead of c8.
 - Added cache-busting to config and data asset fetching to prevent caching of stale files.
+- Update map attribution to show until user interaction.
 
 ## 3.3.0 - 2023-08-17
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,6 +66,7 @@
         "remark-preset-lint-markdown-style-guide": "^5.1.3",
         "remark-preset-lint-recommended": "^6.1.2",
         "remark-validate-links": "^12.1.1",
+        "resize-observer-polyfill": "^1.5.1",
         "typescript": "^5.0.4",
         "vite": "^4.4.6",
         "vite-plugin-svgr": "^3.2.0",
@@ -10526,6 +10527,12 @@
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.8.tgz",
       "integrity": "sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ=="
     },
+    "node_modules/resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
+      "dev": true
+    },
     "node_modules/resolve": {
       "version": "1.22.4",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.4.tgz",
@@ -20167,6 +20174,12 @@
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.8.tgz",
       "integrity": "sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ=="
+    },
+    "resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
+      "dev": true
     },
     "resolve": {
       "version": "1.22.4",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "remark-preset-lint-markdown-style-guide": "^5.1.3",
     "remark-preset-lint-recommended": "^6.1.2",
     "remark-validate-links": "^12.1.1",
+    "resize-observer-polyfill": "^1.5.1",
     "typescript": "^5.0.4",
     "vite": "^4.4.6",
     "vite-plugin-svgr": "^3.2.0",

--- a/src/components/Layout/Content/BottomContent/BottomContent.css
+++ b/src/components/Layout/Content/BottomContent/BottomContent.css
@@ -229,6 +229,43 @@
   opacity: 0.75;
 }
 
+.mapAttribution {
+  font-size: 12px;
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  background-color: #12171a;
+  padding: 4px 6px;
+}
+
+.mapAttribution a {
+  color: #19a1d7;
+  text-decoration: none;
+}
+
+.mapAttribution span {
+  color: #bbb;
+}
+
+.mapAttribution a:hover {
+  text-decoration: underline;
+}
+
+div[data-tooltip-id='attribution-tooltip'] {
+  position: absolute;
+  bottom: 0;
+  right: 10px;
+  z-index: 1;
+  color: #a9b0c1;
+}
+
+div#attribution-tooltip {
+  z-index: 999;
+  white-space: nowrap;
+  padding: 2px;
+  background-color: #12171a;
+}
+
 @media screen and (max-width: 1460px) {
   .BottomContent {
     height: calc(100% - 200px);
@@ -241,7 +278,6 @@
     height: calc(100% - 60px);
     top: 0px;
     margin-top: 60px;
-    background-color: red;
   }
   .BottomContent {
     height: calc(100% - 60px);

--- a/src/components/Layout/Content/BottomContent/BottomContent.jsx
+++ b/src/components/Layout/Content/BottomContent/BottomContent.jsx
@@ -68,6 +68,7 @@ const BottomContent = () => {
   const dispatch = useDispatch()
 
   const abortControllerRef = useRef(null)
+  const attributionTimeout = useRef(null)
 
   const VIEWER_BTN_TEXT = `Launch Your Own ${DEFAULT_APP_NAME}`
 
@@ -165,6 +166,25 @@ const BottomContent = () => {
       })
     }
     return clean
+  }
+
+  const handleAttributionIconMouseEnter = () => {
+    clearTimeout(attributionTimeout.current)
+    dispatch(setshowMapAttribution(true))
+  }
+
+  const handleAttributionIconMouseLeave = () => {
+    attributionTimeout.current = setTimeout(() => {
+      dispatch(setshowMapAttribution(false))
+    }, 500)
+  }
+
+  const handleAttributionTooltipMouseEnter = () => {
+    clearTimeout(attributionTimeout.current)
+  }
+
+  const handleAttributionTooltipMouseLeave = () => {
+    dispatch(setshowMapAttribution(false))
   }
 
   return (
@@ -337,8 +357,8 @@ const BottomContent = () => {
       <div className="attributionTooltipContainer">
         <div
           data-tooltip-id="attribution-tooltip"
-          onMouseEnter={() => dispatch(setshowMapAttribution(true))}
-          onMouseLeave={() => dispatch(setshowMapAttribution(false))}
+          onMouseEnter={handleAttributionIconMouseEnter}
+          onMouseLeave={handleAttributionIconMouseLeave}
         >
           <InfoOutlinedIcon />
         </div>
@@ -349,7 +369,11 @@ const BottomContent = () => {
           noArrow="true"
           isOpen={_showMapAttribution}
         >
-          <div className="mapAttribution leaflet-control-attribution leaflet-control">
+          <div
+            className="mapAttribution leaflet-control-attribution leaflet-control"
+            onMouseEnter={handleAttributionTooltipMouseEnter}
+            onMouseLeave={handleAttributionTooltipMouseLeave}
+          >
             <svg
               aria-hidden="true"
               xmlns="http://www.w3.org/2000/svg"

--- a/src/components/Layout/Content/BottomContent/BottomContent.jsx
+++ b/src/components/Layout/Content/BottomContent/BottomContent.jsx
@@ -344,6 +344,7 @@ const BottomContent = () => {
           id="attribution-tooltip"
           place="left"
           clickable="true"
+          noArrow="true"
           isOpen={_showMapAttribution}
         >
           <div className="mapAttribution leaflet-control-attribution leaflet-control">

--- a/src/components/Layout/Content/BottomContent/BottomContent.jsx
+++ b/src/components/Layout/Content/BottomContent/BottomContent.jsx
@@ -149,12 +149,14 @@ const BottomContent = () => {
 
   useEffect(() => {
     if (_appConfig.BASEMAP_HTML_ATTRIBUTION) {
-      const output = sanitize(String(_appConfig.BASEMAP_HTML_ATTRIBUTION))
+      const output = sanitizeAttribution(
+        String(_appConfig.BASEMAP_HTML_ATTRIBUTION)
+      )
       setmapAttribution(output)
     }
   }, [])
 
-  function sanitize(dirty) {
+  function sanitizeAttribution(dirty) {
     const clean = {
       __html: DOMPurify.sanitize(dirty, {
         USE_PROFILES: { html: true },

--- a/src/components/LeafMap/LeafMap.css
+++ b/src/components/LeafMap/LeafMap.css
@@ -29,38 +29,6 @@
   filter: brightness(1.125) invert(1) contrast(0.9) hue-rotate(0deg) saturate(0);
 }
 
-.mapAttribution {
-  font-size: 12px;
-  color: #bbb;
-  position: absolute;
-  bottom: 0;
-  right: 0;
-  background-color: #12171a;
-  padding: 2px 6px;
-}
-
-.mapAttribution a {
-  color: #19a1d7;
-  text-decoration: none;
-}
-
-.mapAttribution a:hover {
-  text-decoration: underline;
-}
-
-div[data-tooltip-id='attribution-tooltip'] {
-  position: absolute;
-  bottom: 0;
-  right: 10px;
-  z-index: 1;
-  color: #a9b0c1;
-}
-
-div#attribution-tooltip {
-  z-index: 999;
-  white-space: nowrap;
-}
-
 path.leaflet-interactive:focus {
   outline: none;
 }

--- a/src/components/LeafMap/LeafMap.jsx
+++ b/src/components/LeafMap/LeafMap.jsx
@@ -12,7 +12,6 @@ import { MapContainer } from 'react-leaflet/MapContainer'
 import { TileLayer } from 'react-leaflet/TileLayer'
 import { SearchControl, OpenStreetMapProvider } from 'leaflet-geosearch'
 import 'leaflet-geosearch/dist/geosearch.css'
-import 'react-tooltip/dist/react-tooltip.css'
 import {
   mapClickHandler,
   mapCallDebounceNewSearch,

--- a/src/redux/slices/mainSlice.js
+++ b/src/redux/slices/mainSlice.js
@@ -36,7 +36,8 @@ const initialState = {
   cartItems: [],
   showCartModal: false,
   mappedScenes: [],
-  imageOverlayLoading: false
+  imageOverlayLoading: false,
+  showMapAttribution: true
 }
 
 // next, for every key in the initialState
@@ -149,6 +150,9 @@ export const mainSlice = createSlice({
     },
     setimageOverlayLoading: (state, action) => {
       state.imageOverlayLoading = action.payload
+    },
+    setshowMapAttribution: (state, action) => {
+      state.showMapAttribution = action.payload
     }
   }
 })
@@ -190,5 +194,6 @@ export const { setcartItems } = mainSlice.actions
 export const { setshowCartModal } = mainSlice.actions
 export const { setmappedScenes } = mainSlice.actions
 export const { setimageOverlayLoading } = mainSlice.actions
+export const { setshowMapAttribution } = mainSlice.actions
 
 export default mainSlice.reducer

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -3,8 +3,10 @@ import { cleanup } from '@testing-library/react'
 import matchers from '@testing-library/jest-dom/matchers'
 import { mainSliceReset } from './redux/slices/mainSlice'
 import { store } from './redux/store'
+import 'resize-observer-polyfill'
 
 window.HTMLCanvasElement.prototype.getContext = () => {}
+global.ResizeObserver = require('resize-observer-polyfill')
 
 expect.extend(matchers)
 


### PR DESCRIPTION
**Related Issue(s):**

- NA

**Proposed Changes:**

1. Update map attribution to show until user interaction
2. Move attribution out of `LeafMap` component and into `BottomContent` component
3. Add `resize-observer-polyfill` for react-tooltip and testing

### To Test:

- automated tests pass 🍏 `npm run test`

**Test initial render**
- load app
- confirm leaflet & OSM map attribution is showing
- click, or zoom map
- confirm map attribution is no longer rendered after interaction
- hover over "i" icon in bottom right of map
- confirm map attribution renders on hover of icon
- move mouse out of icon
- confirm map attribution no longer renders

**PR Checklist:**

- [X] I have added my changes to the [CHANGELOG](https://github.com/Element84/filmdrop-ui/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
