### PR TITLE
select any results on click not just single scenes

### DIFF
--- a/src/utils/mapHelper.js
+++ b/src/utils/mapHelper.js
@@ -87,7 +87,7 @@ export function mapClickHandler(e) {
   const clickBounds = L.latLngBounds(e.latlng, e.latlng)
   if (map && Object.keys(map).length > 0) {
     const _searchType = store.getState().mainSlice.searchType
-    const _mappedScenes = store.getState().mainSlice.mappedScenes
+    const _searchResults = store.getState().mainSlice.searchResults
 
     clearMapSelection()
 
@@ -101,9 +101,9 @@ export function mapClickHandler(e) {
 
     // pull all items from search results that intersect with the click bounds
     let intersectingFeatures = []
-    if (_mappedScenes !== null) {
-      for (const f in _mappedScenes) {
-        const feature = _mappedScenes[f]
+    if (_searchResults !== null) {
+      for (const f in _searchResults.features) {
+        const feature = _searchResults.features[f]
         const featureBounds = L.geoJSON(feature).getBounds()
         if (featureBounds && featureBounds.intersects(clickBounds)) {
           // highlight layer


### PR DESCRIPTION
**Related Issue(s):**

- NA

**Proposed Changes:**

1. Fixes bug of click events not working for grid-code
2. Behavior fixed: should search all search results aggregate grid-code or individual scenes, not just mapped individual scenes on map click to check for intersect to find footprints/grids under click event and perform selection. 

#### to test:
- load app
- zoom to grid code level
- search
- click on grid
- confirm footprint gets selected and popup result shows
- click around a few time to make sure this works for all grid
- zoom into scene level
- search
- click on scene
- confirm footprint gets selected and popup result shows
- click around a few time to make sure this works for all senes

**PR Checklist:**

- [X] I have added my changes to the [CHANGELOG](https://github.com/Element84/filmdrop-ui/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
