### PR TITLE
#111 Limit bbox precision to 5 decimal places

### DIFF
--- a/src/utils/mapHelper.js
+++ b/src/utils/mapHelper.js
@@ -84,7 +84,12 @@ export function mapClickHandler(e) {
     return
   }
   const map = store.getState().mainSlice.map
-  const clickBounds = L.latLngBounds(e.latlng, e.latlng)
+
+  // Limit the precision of the coordinates to 5 decimal places
+  let lat = parseFloat(e.latlng.lat.toFixed(5))
+  let lng = parseFloat(e.latlng.lng.toFixed(5))
+  const clickBounds = L.latLngBounds([lat, lng], [lat, lng])
+  
   if (map && Object.keys(map).length > 0) {
     const _searchType = store.getState().mainSlice.searchType
     const _searchResults = store.getState().mainSlice.searchResults


### PR DESCRIPTION
**Related Issue(s):**

- #111 

**Proposed Changes:**

1. Limited the precision of the `lat` and `lng` coordinates to 5 decimal places within the `mapClickHandler` function.


**PR Checklist:**

- [x] I have added my changes to the [CHANGELOG](https://github.com/Element84/filmdrop-ui/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.

