### PR TITLE
pass mosaicking bidx param as multiple params instead of csv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 4.2.0 - 2023-10-03
+
+### Changed
+
+- Mosaic tiling parameter `bidx` is now passed as multiple parameters
+  (e.g., `bidx=1&bidx=2&bidx=3`) instead of a single comma-delimited value
+  (e.g., `bidx=1,2,3`). This is to accomodate a change to titler-mosaicjson
+  as of v0.14.0
 
 ## 4.1.0 - 2023-09-14
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "filmdrop-ui",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "filmdrop-ui",
-      "version": "4.1.0",
+      "version": "4.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.11.1",
@@ -4668,9 +4668,10 @@
       }
     },
     "node_modules/get-func-name": {
-      "version": "2.0.0",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -14075,7 +14076,9 @@
       "dev": true
     },
     "get-func-name": {
-      "version": "2.0.0",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
       "dev": true
     },
     "get-intrinsic": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "filmdrop-ui",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "license": "Apache-2.0",
   "dependencies": {
     "@emotion/react": "^11.11.1",

--- a/src/utils/mapHelper.js
+++ b/src/utils/mapHelper.js
@@ -485,7 +485,10 @@ const parameters = {
       const assetBidx = asset && value ? `${asset}|${value}` : null
       return assetBidx && `asset_bidx=${assetBidx}`
     } else {
-      return value && `bidx=${value}`
+      return value
+        ?.split(',')
+        .map((x) => `bidx=${x}`)
+        .join('&')
     }
   }
 }


### PR DESCRIPTION
**Related Issue(s):**

- n/a

**Proposed Changes:**

1. pass mosaicking bidx param as multiple params instead of csv, to accomodate v.14.0 of mosaic-titiler
2. release prep for 4.2.0

**PR Checklist:**

- [X] I have added my changes to the [CHANGELOG](https://github.com/Element84/filmdrop-ui/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
