### PR TITLE
Update link tag for manifest.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+
 - Update link tag for manifest.json so that it uses basic auth credentials, fixes load when running behind CloudFront with basic auth
 
 ## 4.3.0 - 2023-10-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+- Update link tag for manifest.json so that it uses basic auth credentials, fixes load when running behind CloudFront with basic auth
+
 ## 4.3.0 - 2023-10-13
 
 ### Fixed

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
-    <link rel="manifest" href="/manifest.json" />
+    <link rel="manifest" href="/manifest.json" crossorigin="use-credentials" />
     <title>Loading...</title>
   </head>
   <body>


### PR DESCRIPTION
**Proposed Changes:**

1. Update link tag for manifest.json so that it uses basic auth credentials, fixes load when running behind CloudFront with basic auth

**PR Checklist:**

- [x] I have added my changes to the [CHANGELOG](https://github.com/Element84/filmdrop-ui/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
