### PR TITLE
metadata config exception error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10804,8 +10804,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.4.9",
-      "license": "MIT",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.1.tgz",
+      "integrity": "sha512-AXXFaAJ8yebyqzoNB9fu2pHoo/nWX+xZlaRwoeYUxEqBO+Zj4msE5G+BhGBll9lYEKv9Hfks52PAF2X7qDYXQA==",
       "dependencies": {
         "esbuild": "^0.18.10",
         "postcss": "^8.4.27",
@@ -18083,7 +18084,9 @@
       }
     },
     "vite": {
-      "version": "4.4.9",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.1.tgz",
+      "integrity": "sha512-AXXFaAJ8yebyqzoNB9fu2pHoo/nWX+xZlaRwoeYUxEqBO+Zj4msE5G+BhGBll9lYEKv9Hfks52PAF2X7qDYXQA==",
       "requires": {
         "esbuild": "^0.18.10",
         "fsevents": "~2.3.2",

--- a/src/utils/dataHelper.js
+++ b/src/utils/dataHelper.js
@@ -71,21 +71,36 @@ export function setScenesForCartLayer() {
 }
 
 export function processDisplayFieldValues(value) {
-  if (typeof value === 'boolean') {
-    return value.toString()
-  } else if (Array.isArray(value)) {
-    return value.map(processDisplayFieldValues).join(', ')
-  } else if (typeof value === 'number') {
-    return value.toString()
-  } else if (typeof value === 'string') {
-    return value
-  } else if (typeof value === 'object' && value !== null) {
-    const processedObject = {}
-    for (const key in value) {
-      processedObject[key] = processDisplayFieldValues(value[key])
-    }
-    return processedObject
-  } else {
-    return 'Unsupported Type'
+  switch (true) {
+    case value === null:
+    case value === undefined:
+    case typeof value === 'boolean':
+    case typeof value === 'number':
+    case typeof value === 'string':
+      return value.toString()
+    case Array.isArray(value):
+      return value.map(processDisplayFieldValues).join(', ')
+    case typeof value === 'object':
+      return formatNestedObjectDisplayFieldValues(value)
+    default:
+      return 'Unsupported Type'
   }
+}
+
+function formatNestedObjectDisplayFieldValues(inputObject) {
+  function formatValue(value) {
+    if (Array.isArray(value)) {
+      return `[${value.map(formatValue).join(', ')}]`
+    } else if (typeof value === 'object') {
+      return `{${formatObject(value)}}`
+    } else {
+      return value
+    }
+  }
+  function formatObject(obj) {
+    return Object.entries(obj)
+      .map(([key, value]) => `${key}: ${formatValue(value)}`)
+      .join(', ')
+  }
+  return `${formatObject(inputObject)}`
 }

--- a/src/utils/dataHelper.js
+++ b/src/utils/dataHelper.js
@@ -74,6 +74,7 @@ export function processDisplayFieldValues(value) {
   switch (true) {
     case value === null:
     case value === undefined:
+      return 'No Data'
     case typeof value === 'boolean':
     case typeof value === 'number':
     case typeof value === 'string':

--- a/src/utils/dataHelper.test.js
+++ b/src/utils/dataHelper.test.js
@@ -149,29 +149,22 @@ describe('dataHelper', () => {
       expect(actual).toEqual(expected)
     })
 
-    it('should recursively process object values', () => {
+    it('should process nested object values into string', () => {
       const input = {
-        bool: true,
-        arr: [1, 2, 3],
-        num: 42,
-        str: 'Hello, world!',
         nestedObj: {
           nestedBool: false,
-          nestedArr: [4, 5, 6]
+          nestedArr: [4, 5, 6],
+          platform: {
+            eq: 'landsat-8'
+          },
+          collections: ['landsat-c2-l2']
         }
       }
 
       const result = processDisplayFieldValues(input)
-      expect(result).toEqual({
-        bool: 'true',
-        arr: '1, 2, 3',
-        num: '42',
-        str: 'Hello, world!',
-        nestedObj: {
-          nestedBool: 'false',
-          nestedArr: '4, 5, 6'
-        }
-      })
+      expect(result).toEqual(
+        'nestedObj: {nestedBool: false, nestedArr: [4, 5, 6], platform: {eq: landsat-8}, collections: [landsat-c2-l2]}'
+      )
     })
 
     it('returns Unsupported Type for other types', () => {


### PR DESCRIPTION
**Related Issue(s):**

- NA

**Proposed Changes:**

1. Refactor way display fields are formatted
2. Put in basic handling for nested objects (this fixes exception issue, but can be revisited in follow up tickets to better format nested objects for presentation in the UI - needs design work first)
3. Bump vite version to latest (fix for XSS vulnerability)

### To Test:

**Metrics Test**
> initial bug was reported when testing a metrics API
- update config to match metrics URL & `POPUP_DISPLAY_FIELDS`
  - see PR owner for config details
- npm run start
- confirm app loads
- select metrics collection from dropdown
- change start date to be 2022
- zoom into south east US
- hit search
- click on several data footprints
- confirm application does not crash
- confirm Query metadata renders as formatted string of comma separated values

**Standard STAC Test**
- stop app
- update config to be same as earth search viewer
  - see PR owner or just use [earth search config](https://earth-search.console.demo.filmdrop.io/config/config.json)
- load app
- complete a few searches with different collections
- review metadata in popup
- confirm no regressions or errors

**PR Checklist:**

- [X] I have added my changes to the [CHANGELOG](https://github.com/Element84/filmdrop-ui/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
