### PR TITLE
Ba/bug/map extent changing on tab changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Moved example config out of public so it doesn't get added to build.
 - Update readme for config keys showing as `required` to correctly reflect app run requirements.
 
+### Fixed
+
+- Bug fixed for zoom to collection extent running on every collection dropdown re-render.
+- Bug fixed for `select scenes` button not changing to item details tab when clicked.
+
 ## 5.0.0 - 2024-02-27
 
 ### Added

--- a/src/components/CollectionDropdown/CollectionDropdown.jsx
+++ b/src/components/CollectionDropdown/CollectionDropdown.jsx
@@ -62,7 +62,9 @@ const Dropdown = () => {
       dispatch(setSelectedCollectionData(selectedCollection))
       dispatch(setShowZoomNotice(false))
       dispatch(setSearchLoading(false))
-      zoomToCollectionExtent(selectedCollection)
+      if (selectedCollection !== _selectedCollectionData) {
+        zoomToCollectionExtent(selectedCollection)
+      }
     }
   }, [collectionId])
 

--- a/src/components/Layout/Content/RightContent/RightContent.jsx
+++ b/src/components/Layout/Content/RightContent/RightContent.jsx
@@ -13,7 +13,9 @@ import {
   setmappedScenes,
   setSearchLoading,
   setshowMapAttribution,
-  setshowLayerList
+  setshowLayerList,
+  settabSelected,
+  sethasLeftPanelTabChanged
 } from '../../../../redux/slices/mainSlice'
 import {
   setMapZoomLevel,
@@ -133,6 +135,8 @@ const RightContent = () => {
 
   function onSelectAllScenesClicked() {
     selectMappedScenes()
+    dispatch(settabSelected('details'))
+    dispatch(sethasLeftPanelTabChanged(true))
   }
 
   useEffect(() => {


### PR DESCRIPTION
**Related Issue(s):**

- NA

**Proposed Changes:**

1. Bug fixed for zoom to collection extent running on every collection dropdown re-render.
2. Bug fixed for `select scenes` button not changing to item details tab when clicked.

**PR Checklist:**

- [X] I have added my changes to the [CHANGELOG](https://github.com/Element84/filmdrop-ui/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
