### PR TITLE
Ba/add gitkeep config dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Added .gitkeep to empty config directory so it gets put into version control.
+
 ## 5.0.1 - 2024-03-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Added .gitkeep to empty config directory so it gets put into version control.
+- Added `.gitkeep` to empty config directory so it gets put into version control.
 
 ## 5.0.1 - 2024-03-04
 


### PR DESCRIPTION
**Related Issue(s):**

- NA

**Proposed Changes:**

1. Adds `.gitkeep` to make sure empty `./public/config` dir exists in version control

**PR Checklist:**

- [X] I have added my changes to the [CHANGELOG](https://github.com/Element84/filmdrop-ui/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
