### PR TITLE
Ba/feature/log app version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Added initial console log of application deploy version number read from `package.json`
+
 ## 5.0.2 - 2024-03-06
 
 ### Added

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -26,7 +26,7 @@ function App() {
     try {
       console.log('Version: ' + process.env.REACT_APP_VERSION)
     } catch (err) {
-      console.log('Version: undefined')
+      console.error('Error logging version:', err)
     }
   }, [])
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -23,6 +23,11 @@ function App() {
 
   useEffect(() => {
     LoadConfigIntoStateService()
+    try {
+      console.log('Version: ' + process.env.REACT_APP_VERSION)
+    } catch (err) {
+      console.log('Version: undefined')
+    }
   }, [])
 
   useEffect(() => {

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -9,6 +9,11 @@ import svgrPlugin from 'vite-plugin-svgr'
 
 export default defineConfig({
   base: './',
+  define: {
+    'process.env.REACT_APP_VERSION': JSON.stringify(
+      require('./package.json').version
+    )
+  },
   plugins: [react(), viteTsconfigPaths(), svgrPlugin()],
   build: {
     outDir: 'build'


### PR DESCRIPTION
**Related Issue(s):**

- NA

**Proposed Changes:**

1. Adds initial console log of application deploy version number read from `package.json`

Example:

![Screenshot 2024-03-20 at 1 14 37 PM](https://github.com/Element84/filmdrop-ui/assets/21375568/a69502a1-c3f5-44a7-981c-25a2a9f40c51)


**PR Checklist:**

- [X] I have added my changes to the [CHANGELOG](https://github.com/Element84/filmdrop-ui/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
