### PR TITLE
support nodata parameter for tiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Added initial console log of application deploy version number read from `package.json`
+- Add support for `nodata` to tiling configurations.
 
 ## 5.0.2 - 2024-03-06
 

--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ The configurations include:
   image to composite.
 - `colormap_name`: the colormap to use for mapping values (typically used for single band)
 - `rescale`: the rescale range to apply prior to color mapping (typically used for single band)
+- `nodata`: the nodata value to use, if not in image metadata
 
 ### Mosaic Tiling Configuration
 

--- a/src/utils/mapHelper.js
+++ b/src/utils/mapHelper.js
@@ -444,6 +444,9 @@ const constructSceneTilerParams = (collection) => {
   const assetBidx = parameters.bidx(tilerParams, collection, asset)
   if (assetBidx) params.push(assetBidx)
 
+  const nodata = parameters.nodata(tilerParams, collection)
+  if (nodata) params.push(nodata)
+
   const colorFormula = parameters.colorFormula(tilerParams, collection)
   if (colorFormula) params.push(colorFormula)
 
@@ -481,6 +484,10 @@ const constructSceneAssetsParam = (collection, tilerParams) => {
 }
 
 const parameters = {
+  nodata: (tilerParams, collection) => {
+    const value = tilerParams[collection]?.nodata
+    return value == null ? null : `nodata=${value}`
+  },
   colorFormula: (tilerParams, collection) => {
     const value = tilerParams[collection]?.color_formula
     return value && `color_formula=${value}`
@@ -539,6 +546,9 @@ export const constructMosaicTilerParams = (collection) => {
 
   const bidx = parameters.bidx(tilerParams, collection)
   if (bidx) params.push(bidx)
+
+  const nodata = parameters.nodata(tilerParams, collection)
+  if (nodata) params.push(nodata)
 
   const colorFormula = parameters.colorFormula(tilerParams, collection)
   if (colorFormula) params.push(colorFormula)


### PR DESCRIPTION
**Related Issue(s):**

- n/a

**Proposed Changes:**

1. support `nodata` parameter in tiling parameters, so that nodata values will be interpreted by titiler as transparent rather than black

**PR Checklist:**

- [X] I have added my changes to the [CHANGELOG](https://github.com/Element84/filmdrop-ui/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.

## Testing

1. Without the nodata parameter set: tile a scene that has a partial coverage from Earth Search sentinel-2-c1-l2a. Notice that the area that is not covered in the scene is black instead of transparent (e.g., black covers the base map)

2. With the nodata parameter set to 0 for collection sentinel-2-c1-l2a: tile a scene that has a partial coverage from Earth Search sentinel-2-c1-l2a. Notice that the area that is not covered in the scene is transparent and the base map can be seen.
