### PR TITLE
find self link by rel for STAC API Item link href

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## unreleased
+
+### Fixed
+
+- STAC API Item link used the first link in the links array, instead of looking
+  up the "self" relation link by "rel" value
+
 ## 5.1.0 - 2024-04-10
 
 ### Added

--- a/src/components/PopupResult/PopupResult.jsx
+++ b/src/components/PopupResult/PopupResult.jsx
@@ -70,7 +70,9 @@ const PopupResult = (props) => {
             {_appConfig.STAC_LINK_ENABLED && (
               <div className="detailRow">
                 <a
-                  href={props.result.links[0].href.toString()}
+                  href={props.result?.links
+                    ?.find((x) => x?.rel === 'self')
+                    ?.href?.toString()}
                   target="_blank"
                   rel="noreferrer"
                   className="popupResultDetailsRowValue popupResultDetailsHrefLink"


### PR DESCRIPTION
**Related Issue(s):**

- n/a

**Proposed Changes:**

1. lookup stac api item link url by rel=self rather than just taking the first on in the list

**PR Checklist:**

- [X] I have added my changes to the [CHANGELOG](https://github.com/Element84/filmdrop-ui/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
