### PR TITLE
fix another bad self link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 5.4.0 - 2024-05-16
+
+### Fixed
+
+- Another instance of STAC API Item link using the first link in the links array,
+  instead of looking up the "self" relation link by "rel" value.
+
 ## 5.3.0 - 2024-05-14
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "filmdrop-ui",
-  "version": "5.2.0",
+  "version": "5.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "filmdrop-ui",
-      "version": "5.2.0",
+      "version": "5.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.11.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "filmdrop-ui",
-  "version": "5.2.0",
+  "version": "5.4.0",
   "license": "Apache-2.0",
   "dependencies": {
     "@emotion/react": "^11.11.4",

--- a/src/utils/mapHelper.js
+++ b/src/utils/mapHelper.js
@@ -372,7 +372,9 @@ function addImageOverlay(item) {
 
   clearLayer('clickedSceneImageLayer')
 
-  const featureURL = item.links[0].href
+  const featureURL = item?.links
+    ?.find((x) => x?.rel === 'self')
+    ?.href?.toString()
   const tilerParams = constructSceneTilerParams(_selectedCollectionData.id)
 
   fetch(featureURL, {


### PR DESCRIPTION
**Related Issue(s):**

- n/a

**Proposed Changes:**

1. fix another instance where the `self` link was assumed to be the first one, instead of finding the link by `rel=self`


**PR Checklist:**

- [X] I have added my changes to the [CHANGELOG](https://github.com/Element84/filmdrop-ui/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
