### PR TITLE
Fix Material UI Grid usage

### DIFF
--- a/src/components/CloudSlider/CloudSlider.jsx
+++ b/src/components/CloudSlider/CloudSlider.jsx
@@ -78,7 +78,7 @@ const CloudSlider = () => {
           spacing={2}
           alignItems="center"
         >
-          <Grid item xs>
+          <Grid size="grow">
             <Slider
               sx={{
                 '& .MuiSlider-thumb': {
@@ -92,7 +92,7 @@ const CloudSlider = () => {
               disabled={disabled}
             />
           </Grid>
-          <Grid item>
+          <Grid size="auto">
             <Input
               value={value}
               size="small"

--- a/src/components/CollectionDropdown/CollectionDropdown.jsx
+++ b/src/components/CollectionDropdown/CollectionDropdown.jsx
@@ -83,7 +83,7 @@ const Dropdown = () => {
     <Stack>
       <label htmlFor="collectionDropdown">Collection</label>
       <Grid container alignItems="center">
-        <Grid item xs>
+        <Grid size="grow">
           <NativeSelect
             id="collectionDropdown"
             value={collectionId}

--- a/src/components/ViewSelector/ViewSelector.jsx
+++ b/src/components/ViewSelector/ViewSelector.jsx
@@ -34,7 +34,7 @@ const ViewSelector = () => {
       <Stack sx={{ width: 165 }} className="viewSelector">
         <label htmlFor="ViewModeToggle">View Mode</label>
         <Grid container spacing={2} alignItems="center">
-          <Grid item xs>
+          <Grid size="grow">
             <ButtonGroup
               variant="contained"
               aria-label="outlined primary button group"


### PR DESCRIPTION
Fixes bug introduced by recent Material UI package update that causes the cloud slider to render incorrectly. Updates the CloudSlider, CollectionDropdown, and ViewSelector components.

**Related Issue(s):**

- None

**Proposed Changes:**

1. Use updated MUI patterns

**PR Checklist:**

- [x] I have added my changes to the [CHANGELOG](https://github.com/Element84/filmdrop-ui/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
