### PR TITLE
Add support for new aggregation name centroid_geohex_grid_frequency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Overhauled `README.md` following best practices with improved structure, quick start guide, and developer section
 - Added `CONFIGURATION.md` with details on Config structure and including a migration guide
 - Consolidated duplicate sections in `README.md` for clearer documentation
+- Added backwards compatibility for stac-server aggregation names
+  - Now supports both new (stac-server >= 3.6.0) and old (deprecated) aggregation names
+  - Automatically detects and uses appropriate aggregation name based on STAC API capabilities
+  - New names: `centroid_geohex_grid_frequency`, `centroid_geohash_grid_frequency`, `centroid_geotile_grid_frequency`
+  - Old names: `grid_geohex_frequency`, `grid_geohash_frequency`, `grid_geotile_frequency`
+  - Ensures compatibility with Earth Search STAC API and other APIs using deprecated names
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Some FilmDrop features require specific STAC API extensions:
 - **Aggregation Views** - [Aggregation Extension](https://github.com/stac-api-extensions/aggregation)
   - Hex view requires items with `proj:centroid` property
   - Currently supported by [stac-server](https://github.com/stac-utils/stac-server) and stac-fastapi-elasticsearch-opensearch
+  - The aggregation `centroid_geohex_grid_frequency` or `grid_geohex_frequency` (Deprecated) must be advertised by the `/aggregations` endpoint
 
 - **Grid Code Aggregation** - Custom `grid:code` property
   - Items must include grid identifier (e.g., MGRS, WRS2)

--- a/src/testing/shared-mocks.js
+++ b/src/testing/shared-mocks.js
@@ -142,12 +142,27 @@ export const mockCollectionsData = [
         frequency_distribution_data_type: 'string'
       },
       {
+        name: 'centroid_geohex_grid_frequency',
+        data_type: 'frequency_distribution',
+        frequency_distribution_data_type: 'string'
+      },
+      {
         name: 'grid_geohash_frequency',
         data_type: 'frequency_distribution',
         frequency_distribution_data_type: 'string'
       },
       {
+        name: 'centroid_geohash_grid_frequency',
+        data_type: 'frequency_distribution',
+        frequency_distribution_data_type: 'string'
+      },
+      {
         name: 'grid_geotile_frequency',
+        data_type: 'frequency_distribution',
+        frequency_distribution_data_type: 'string'
+      },
+      {
+        name: 'centroid_geotile_grid_frequency',
         data_type: 'frequency_distribution',
         frequency_distribution_data_type: 'string'
       }
@@ -296,12 +311,27 @@ export const mockCollectionsData = [
         frequency_distribution_data_type: 'string'
       },
       {
+        name: 'centroid_geohex_grid_frequency',
+        data_type: 'frequency_distribution',
+        frequency_distribution_data_type: 'string'
+      },
+      {
         name: 'grid_geohash_frequency',
         data_type: 'frequency_distribution',
         frequency_distribution_data_type: 'string'
       },
       {
+        name: 'centroid_geohash_grid_frequency',
+        data_type: 'frequency_distribution',
+        frequency_distribution_data_type: 'string'
+      },
+      {
         name: 'grid_geotile_frequency',
+        data_type: 'frequency_distribution',
+        frequency_distribution_data_type: 'string'
+      },
+      {
+        name: 'centroid_geotile_grid_frequency',
         data_type: 'frequency_distribution',
         frequency_distribution_data_type: 'string'
       }

--- a/src/utils/searchHelper.js
+++ b/src/utils/searchHelper.js
@@ -44,8 +44,11 @@ export function newSearch() {
 
   const currentMapZoomLevel = getCurrentMapZoomLevel()
 
+  // Check for both new (stac-server >= 3.6.0) and old (deprecated) aggregation names
   const includesGeoHex = _selectedCollection.aggregations?.some(
-    (el) => el.name === 'grid_geohex_frequency'
+    (el) =>
+      el.name === 'centroid_geohex_grid_frequency' ||
+      el.name === 'grid_geohex_frequency'
   )
   const includesGridCode = _selectedCollection.aggregations?.some(
     (el) => el.name === 'grid_code_frequency'
@@ -185,7 +188,15 @@ function buildSearchAggregateParams(gridType) {
         precision = 5
         break
     }
-    aggregations = `grid_geohex_frequency,total_count&grid_geohex_frequency_precision=${precision}`
+
+    // Determine which aggregation name to use (prefer new, fallback to old for backwards compatibility)
+    const hasNewAggregation = _selectedCollection.aggregations?.some(
+      (el) => el.name === 'centroid_geohex_grid_frequency'
+    )
+    const aggregationName = hasNewAggregation
+      ? 'centroid_geohex_grid_frequency'
+      : 'grid_geohex_frequency'
+    aggregations = `${aggregationName},total_count&${aggregationName}_precision=${precision}`
   } else {
     aggregations = `grid_code_frequency,total_count`
   }
@@ -246,15 +257,19 @@ function buildUrlParamFromBBOX() {
 export function mapHexGridFromJson(json) {
   let largestRatio = 0
   let largestFrequency = 0
-  const buckets = json.aggregations?.find(
-    (el) => el.name === 'grid_geohex_frequency'
-  ).buckets
+
+  // Check for both new (stac-server >= 3.6.0) and old (deprecated) aggregation names
+  const hexAggregation = json.aggregations?.find(
+    (el) =>
+      el.name === 'centroid_geohex_grid_frequency' ||
+      el.name === 'grid_geohex_frequency'
+  )
+
+  const buckets = hexAggregation?.buckets
   const numberMatched = json?.aggregations?.find(
     (el) => el.name === 'total_count'
   )?.value
-  const overflow = json?.aggregations.find(
-    (el) => el.name === 'grid_geohex_frequency'
-  ).overflow
+  const overflow = hexAggregation?.overflow
 
   const convertedItems = buckets.map((feature) => {
     const hexBoundary = h3.cellToBoundary(feature.key, true)


### PR DESCRIPTION
Fixes compatibility issues with stac-server >= 3.6.0 which deprecated aggregation names in favor of new naming convention.

##  Changes

- Detects and uses both new and old aggregation names:
    - New (>= 3.6.0): centroid_geohex_grid_frequency, centroid_geohash_grid_frequency, centroid_geotile_grid_frequency
    - Old (deprecated): grid_geohex_frequency, grid_geohash_frequency, grid_geotile_grid_frequency
- Automatically selects appropriate aggregation name based on STAC API capabilities
- Updates response parsing to handle both naming conventions


Ensures FilmDrop UI works with:

✅ stac-server < 3.6.0 (old names)
✅ stac-server >= 3.6.0 (new names)
✅ Earth Search STAC API (uses old names)

Related Issues:
- Replaces PR #449 