### PR TITLE
update application name to FilmDrop UI

### DIFF
--- a/ADRs/adr_config_refactor_11.8.23.md
+++ b/ADRs/adr_config_refactor_11.8.23.md
@@ -133,7 +133,7 @@ deciders: Brad Andrick, Matt Hanson, Phil Varner
       "sar:polarizations"
     ]
   },
-  "APP_NAME": "Filmdrop Console",
+  "APP_NAME": "Filmdrop UI",
   "APP_FAVICON": "exampleFavicon.ico",
   "MAP_ZOOM": 3,
   "MAP_CENTER": [30, 0],
@@ -179,7 +179,7 @@ deciders: Brad Andrick, Matt Hanson, Phil Varner
 {
   "CONSOLE_SETTINGS": {
     // settings for top level console/parent container app
-    "APP_NAME": "Filmdrop Console",
+    "APP_NAME": "Filmdrop UI",
     "APP_FAVICON": "exampleFavicon.ico",
     "LOGO_URL": "./logo.png",
     "LOGO_ALT": "Alt description for my custom logo",
@@ -192,7 +192,7 @@ deciders: Brad Andrick, Matt Hanson, Phil Varner
   "APP_SETTINGS": {
     // settings for each individual nested 'app'
     "CORE_APPS": {
-      // settings for core apps included with base FD console
+      // settings for core apps included with base FD UI
       "SEARCH": {
         // all settings for search app here
         // this would be all existing console FD-UI search/map settings from old config

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -58,14 +58,14 @@ After building with `npm run build`, place your config at `build/config/config.j
 
 #### Application Branding
 
-| Parameter     | Type   | Default              | Description                                                                                                  |
-| ------------- | ------ | -------------------- | ------------------------------------------------------------------------------------------------------------ |
-| `APP_NAME`    | String | `"FilmDrop Console"` | Application name used in HTML title and UI                                                                   |
-| `APP_FAVICON` | String | -                    | Custom favicon filename (`.ico` or `.png`) in `/config` directory                                            |
-| `LOGO_URL`    | String | -                    | URL to custom logo image                                                                                     |
-| `LOGO_ALT`    | String | -                    | Alt text for custom logo                                                                                     |
-| `PUBLIC_URL`  | String | -                    | Public URL for the application (useful with CDNs)                                                            |
-| `BRAND_LOGO`  | Object | -                    | Brand logo configuration with clickable hyperlink. See [Brand Logo Configuration](#brand-logo-configuration) |
+| Parameter     | Type   | Default         | Description                                                                                                  |
+| ------------- | ------ | --------------- | ------------------------------------------------------------------------------------------------------------ |
+| `APP_NAME`    | String | `"FilmDrop UI"` | Application name used in HTML title and UI                                                                   |
+| `APP_FAVICON` | String | -               | Custom favicon filename (`.ico` or `.png`) in `/config` directory                                            |
+| `LOGO_URL`    | String | -               | URL to custom logo image                                                                                     |
+| `LOGO_ALT`    | String | -               | Alt text for custom logo                                                                                     |
+| `PUBLIC_URL`  | String | -               | Public URL for the application (useful with CDNs)                                                            |
+| `BRAND_LOGO`  | Object | -               | Brand logo configuration with clickable hyperlink. See [Brand Logo Configuration](#brand-logo-configuration) |
 
 #### UI Features
 

--- a/config_helper/config-new-format-example.json
+++ b/config_helper/config-new-format-example.json
@@ -142,6 +142,6 @@
     }
   },
 
-  "APP_NAME": "Filmdrop Console",
+  "APP_NAME": "Filmdrop UI",
   "EXPORT_ENABLED": true
 }

--- a/config_helper/config.example.json
+++ b/config_helper/config.example.json
@@ -830,7 +830,7 @@
       ]
     }
   },
-  "APP_NAME": "Filmdrop Console",
+  "APP_NAME": "Filmdrop UI",
   "APP_FAVICON": "exampleFavicon.ico",
   "MAP_ZOOM": 3,
   "MAP_CENTER": [30, 0],

--- a/config_helper/lint_config.py
+++ b/config_helper/lint_config.py
@@ -4,7 +4,7 @@ Usage: python3 lint_config.py path/to/config.json
 Purpose: Lints a config.json configuration file used by a deployment of the Filmdrop UI application (https://github.com/Element84/filmdrop-ui).
 Checks for missing required keys, extra keys, type errors, and optional keys not included.
 
-Supported console version this works for: 5.0.0
+Supported UI version this works for: 5.0.0
 """
 
 import sys


### PR DESCRIPTION
update application name from "Filmdrop Console" to "Filmdrop UI" in configuration files

**Related Issue(s):**

- #460 

**PR Checklist:**

- [x] I have added my changes to the [CHANGELOG](https://github.com/Element84/filmdrop-ui/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.

Closes #460 