### PR TITLE
Improve GeoJSON upload error handling with normalized STAC errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added a NumericRangeInputs component for numeric fields that supports unbounded, min-only, and max-only queryables.
 - Added unit tests for bbox coordinate rounding/clamping (`mapHelper`) and URL/search param bbox handling (`searchHelper`).
 - Added mosaic search caching metadata to track the last mosaic request and top N item IDs for re-use across searches.
+- Added STAC error normalization helpers (`stacErrorHelper`) and unit tests for normalized HTTP responses and network failures; oversized error bodies are truncated using `MAX_STAC_ERROR_BODY_CHARS`.
+- Added `validateUploadedGeometry` in `searchHelper` and unit tests for upload validation independent of map view and zoom.
+- Added unit tests for normalized error handling in search, aggregate, and mosaic STAC client modules.
+- Added optional `AbortSignal` support on `SearchService`, `fetchTopItemsForMosaic`, `AggregateSearchService`, and `AddMosaicService`;
+  `newSearch` accepts an optional `signal` and forwards it to those calls.
 
 ### Changed
 
@@ -20,6 +25,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Item Details field grid: column layout set to `minmax(0, 40%) 1fr`, alignment and padding adjusted for clearer spacing and to avoid overflowing text.
 - Updated mosaic search flow to fetch a small set of top items for comparison before creating a new mosaic, reducing redundant mosaic tiler requests.
 - Prevented `newSearch` from clearing map layers and results when running in mosaic view where an existing mosaic image layer is being reused.
+- Centralized STAC request headers in `buildStacRequestHeaders` (`stacRequest`) for search, aggregate, and mosaic top-items prefetch requests.
+- GeoJSON upload flow: preflight STAC search validates the uploaded geometry; on success the AOI is added to the map and `newSearch` runs; inline `Alert` for normalized errors with scrollable details;
+  modal flex layout, `max-height`, double-submit guard (`submissionInFlightRef`); **Cancel** clears Redux AOI and the draw layer and **aborts** in-flight upload/search requests.
+  **Aborted** requests do not apply search results. A failed post-upload search clears the AOI so it does not drive later queries
+  (geometry may appear briefly before the main search completes). `newSearch` still runs synchronously up to URL/layer setup before the first `await`;
+  cancellation stops network completion and result application, not full URL rollback.
+- STAC client modules: return structured error objects and log with the same `contextLabel` passed into normalization (per-service defaults: search, aggregate, mosaic, mosaic top-items prefetch).
 
 ### Fixed
 
@@ -29,6 +41,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Resolve dependency vulnerabilities: DOMPurify XSS (GHSA-v2wj-7wpq-c8vv), Rollup path
   traversal (GHSA-mw96-cpmx-2vgc); upgrade `dompurify` to ^3.3.2, override `rollup` to ^4.59.0.
 - Fixed repeated mosaic layer recreation on identical mosaic searches by reusing the existing mosaic image layer when the request parameters and top items have not changed.
+- Dismissing the GeoJSON upload modal no longer leaves a staged AOI driving later searches; in-flight fetches are aborted so late completions do not repopulate results after **Cancel**.
+- Non-upload flows do not inherit upload-specific error copy; mosaic prefetch uses a dedicated summary to avoid redundant generic search messaging.
 
 ## v7.1.0-pre - 2026-01-15
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,7 +75,7 @@
         "remark-validate-links": "^13.0.1",
         "resize-observer-polyfill": "^1.5.1",
         "typescript": "^5.9.2",
-        "vite": "^7.2.7",
+        "vite": "^7.3.2",
         "vite-plugin-svgr": "^4.5.0",
         "vite-tsconfig-paths": "^6.1.1",
         "vitest": "^4.0.18"
@@ -713,9 +713,9 @@
       "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg=="
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.8.tgz",
-      "integrity": "sha512-urAvrUedIqEiFR3FYSLTWQgLu5tb+m0qZw0NBEasUeo6wuqatkMDaRT+1uABiGXEu5vqgPd7FGE1BhsAIy9QVA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
       "cpu": [
         "ppc64"
       ],
@@ -729,9 +729,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.25.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.8.tgz",
-      "integrity": "sha512-RONsAvGCz5oWyePVnLdZY/HHwA++nxYWIX1atInlaW6SEkwq6XkP3+cb825EUcRs5Vss/lGh/2YxAb5xqc07Uw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
       "cpu": [
         "arm"
       ],
@@ -745,9 +745,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.8.tgz",
-      "integrity": "sha512-OD3p7LYzWpLhZEyATcTSJ67qB5D+20vbtr6vHlHWSQYhKtzUYrETuWThmzFpZtFsBIxRvhO07+UgVA9m0i/O1w==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
       "cpu": [
         "arm64"
       ],
@@ -761,9 +761,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.25.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.8.tgz",
-      "integrity": "sha512-yJAVPklM5+4+9dTeKwHOaA+LQkmrKFX96BM0A/2zQrbS6ENCmxc4OVoBs5dPkCCak2roAD+jKCdnmOqKszPkjA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
       "cpu": [
         "x64"
       ],
@@ -777,9 +777,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.8.tgz",
-      "integrity": "sha512-Jw0mxgIaYX6R8ODrdkLLPwBqHTtYHJSmzzd+QeytSugzQ0Vg4c5rDky5VgkoowbZQahCbsv1rT1KW72MPIkevw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
       "cpu": [
         "arm64"
       ],
@@ -793,9 +793,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.8.tgz",
-      "integrity": "sha512-Vh2gLxxHnuoQ+GjPNvDSDRpoBCUzY4Pu0kBqMBDlK4fuWbKgGtmDIeEC081xi26PPjn+1tct+Bh8FjyLlw1Zlg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
       "cpu": [
         "x64"
       ],
@@ -809,9 +809,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.8.tgz",
-      "integrity": "sha512-YPJ7hDQ9DnNe5vxOm6jaie9QsTwcKedPvizTVlqWG9GBSq+BuyWEDazlGaDTC5NGU4QJd666V0yqCBL2oWKPfA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
       "cpu": [
         "arm64"
       ],
@@ -825,9 +825,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.8.tgz",
-      "integrity": "sha512-MmaEXxQRdXNFsRN/KcIimLnSJrk2r5H8v+WVafRWz5xdSVmWLoITZQXcgehI2ZE6gioE6HirAEToM/RvFBeuhw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
       "cpu": [
         "x64"
       ],
@@ -841,9 +841,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.8.tgz",
-      "integrity": "sha512-FuzEP9BixzZohl1kLf76KEVOsxtIBFwCaLupVuk4eFVnOZfU+Wsn+x5Ryam7nILV2pkq2TqQM9EZPsOBuMC+kg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
       "cpu": [
         "arm"
       ],
@@ -857,9 +857,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.8.tgz",
-      "integrity": "sha512-WIgg00ARWv/uYLU7lsuDK00d/hHSfES5BzdWAdAig1ioV5kaFNrtK8EqGcUBJhYqotlUByUKz5Qo6u8tt7iD/w==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
       "cpu": [
         "arm64"
       ],
@@ -873,9 +873,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.8.tgz",
-      "integrity": "sha512-A1D9YzRX1i+1AJZuFFUMP1E9fMaYY+GnSQil9Tlw05utlE86EKTUA7RjwHDkEitmLYiFsRd9HwKBPEftNdBfjg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
       "cpu": [
         "ia32"
       ],
@@ -889,9 +889,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.8.tgz",
-      "integrity": "sha512-O7k1J/dwHkY1RMVvglFHl1HzutGEFFZ3kNiDMSOyUrB7WcoHGf96Sh+64nTRT26l3GMbCW01Ekh/ThKM5iI7hQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
       "cpu": [
         "loong64"
       ],
@@ -905,9 +905,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.8.tgz",
-      "integrity": "sha512-uv+dqfRazte3BzfMp8PAQXmdGHQt2oC/y2ovwpTteqrMx2lwaksiFZ/bdkXJC19ttTvNXBuWH53zy/aTj1FgGw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
       "cpu": [
         "mips64el"
       ],
@@ -921,9 +921,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.8.tgz",
-      "integrity": "sha512-GyG0KcMi1GBavP5JgAkkstMGyMholMDybAf8wF5A70CALlDM2p/f7YFE7H92eDeH/VBtFJA5MT4nRPDGg4JuzQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
       "cpu": [
         "ppc64"
       ],
@@ -937,9 +937,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.8.tgz",
-      "integrity": "sha512-rAqDYFv3yzMrq7GIcen3XP7TUEG/4LK86LUPMIz6RT8A6pRIDn0sDcvjudVZBiiTcZCY9y2SgYX2lgK3AF+1eg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
       "cpu": [
         "riscv64"
       ],
@@ -953,9 +953,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.8.tgz",
-      "integrity": "sha512-Xutvh6VjlbcHpsIIbwY8GVRbwoviWT19tFhgdA7DlenLGC/mbc3lBoVb7jxj9Z+eyGqvcnSyIltYUrkKzWqSvg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
       "cpu": [
         "s390x"
       ],
@@ -969,9 +969,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.8.tgz",
-      "integrity": "sha512-ASFQhgY4ElXh3nDcOMTkQero4b1lgubskNlhIfJrsH5OKZXDpUAKBlNS0Kx81jwOBp+HCeZqmoJuihTv57/jvQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
       "cpu": [
         "x64"
       ],
@@ -985,9 +985,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.8.tgz",
-      "integrity": "sha512-d1KfruIeohqAi6SA+gENMuObDbEjn22olAR7egqnkCD9DGBG0wsEARotkLgXDu6c4ncgWTZJtN5vcgxzWRMzcw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
       "cpu": [
         "arm64"
       ],
@@ -1001,9 +1001,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.8.tgz",
-      "integrity": "sha512-nVDCkrvx2ua+XQNyfrujIG38+YGyuy2Ru9kKVNyh5jAys6n+l44tTtToqHjino2My8VAY6Lw9H7RI73XFi66Cg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
       "cpu": [
         "x64"
       ],
@@ -1017,9 +1017,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.8.tgz",
-      "integrity": "sha512-j8HgrDuSJFAujkivSMSfPQSAa5Fxbvk4rgNAS5i3K+r8s1X0p1uOO2Hl2xNsGFppOeHOLAVgYwDVlmxhq5h+SQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
       "cpu": [
         "arm64"
       ],
@@ -1033,9 +1033,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.8.tgz",
-      "integrity": "sha512-1h8MUAwa0VhNCDp6Af0HToI2TJFAn1uqT9Al6DJVzdIBAd21m/G0Yfc77KDM3uF3T/YaOgQq3qTJHPbTOInaIQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
       "cpu": [
         "x64"
       ],
@@ -1049,9 +1049,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.25.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.8.tgz",
-      "integrity": "sha512-r2nVa5SIK9tSWd0kJd9HCffnDHKchTGikb//9c7HX+r+wHYCpQrSgxhlY6KWV1nFo1l4KFbsMlHk+L6fekLsUg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
       "cpu": [
         "arm64"
       ],
@@ -1065,9 +1065,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.8.tgz",
-      "integrity": "sha512-zUlaP2S12YhQ2UzUfcCuMDHQFJyKABkAjvO5YSndMiIkMimPmxA+BYSBikWgsRpvyxuRnow4nS5NPnf9fpv41w==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
       "cpu": [
         "x64"
       ],
@@ -1081,9 +1081,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.8.tgz",
-      "integrity": "sha512-YEGFFWESlPva8hGL+zvj2z/SaK+pH0SwOM0Nc/d+rVnW7GSTFlLBGzZkuSU9kFIGIo8q9X3ucpZhu8PDN5A2sQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
       "cpu": [
         "arm64"
       ],
@@ -1097,9 +1097,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.8.tgz",
-      "integrity": "sha512-hiGgGC6KZ5LZz58OL/+qVVoZiuZlUYlYHNAmczOm7bs2oE1XriPFi5ZHHrS8ACpV5EjySrnoCKmcbQMN+ojnHg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
       "cpu": [
         "ia32"
       ],
@@ -1113,9 +1113,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.25.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.8.tgz",
-      "integrity": "sha512-cn3Yr7+OaaZq1c+2pe+8yxC8E144SReCQjN6/2ynubzYjvyqZjTXfQJpAcQpsdJq3My7XADANiYGHoFC69pLQw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
       "cpu": [
         "x64"
       ],
@@ -2382,9 +2382,9 @@
       }
     },
     "node_modules/@rollup/pluginutils/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3990,6 +3990,19 @@
         "node": ">= 8"
       }
     },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -4865,9 +4878,9 @@
       }
     },
     "node_modules/cosmiconfig/node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
       "license": "ISC",
       "engines": {
         "node": ">= 6"
@@ -5507,9 +5520,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.25.8",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.8.tgz",
-      "integrity": "sha512-vVC0USHGtMi8+R4Kz8rt6JhEWLxsv9Rnu/lGYbPR8u47B+DCBksq9JarW0zOO7bs37hyOK1l2/oqtbciutL5+Q==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -5519,32 +5532,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.8",
-        "@esbuild/android-arm": "0.25.8",
-        "@esbuild/android-arm64": "0.25.8",
-        "@esbuild/android-x64": "0.25.8",
-        "@esbuild/darwin-arm64": "0.25.8",
-        "@esbuild/darwin-x64": "0.25.8",
-        "@esbuild/freebsd-arm64": "0.25.8",
-        "@esbuild/freebsd-x64": "0.25.8",
-        "@esbuild/linux-arm": "0.25.8",
-        "@esbuild/linux-arm64": "0.25.8",
-        "@esbuild/linux-ia32": "0.25.8",
-        "@esbuild/linux-loong64": "0.25.8",
-        "@esbuild/linux-mips64el": "0.25.8",
-        "@esbuild/linux-ppc64": "0.25.8",
-        "@esbuild/linux-riscv64": "0.25.8",
-        "@esbuild/linux-s390x": "0.25.8",
-        "@esbuild/linux-x64": "0.25.8",
-        "@esbuild/netbsd-arm64": "0.25.8",
-        "@esbuild/netbsd-x64": "0.25.8",
-        "@esbuild/openbsd-arm64": "0.25.8",
-        "@esbuild/openbsd-x64": "0.25.8",
-        "@esbuild/openharmony-arm64": "0.25.8",
-        "@esbuild/sunos-x64": "0.25.8",
-        "@esbuild/win32-arm64": "0.25.8",
-        "@esbuild/win32-ia32": "0.25.8",
-        "@esbuild/win32-x64": "0.25.8"
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
       }
     },
     "node_modules/escalade": {
@@ -9001,6 +9014,19 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -9578,18 +9604,6 @@
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
-    },
-    "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
     },
     "node_modules/pluralize": {
       "version": "8.0.0",
@@ -10189,6 +10203,19 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/redent": {
@@ -14138,9 +14165,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -15162,12 +15189,12 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.2.7",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.2.7.tgz",
-      "integrity": "sha512-ITcnkFeR3+fI8P1wMgItjGrR10170d8auB4EpMLPqmx6uxElH3a/hHGQabSHKdqd4FXWO1nFIp9rRn7JQ34ACQ==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.25.0",
+        "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
         "picomatch": "^4.0.3",
         "postcss": "^8.5.6",
@@ -15283,9 +15310,9 @@
       }
     },
     "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -15373,9 +15400,9 @@
       }
     },
     "node_modules/vitest/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -15693,9 +15720,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "devOptional": true,
       "license": "ISC",
       "bin": {
@@ -15703,6 +15730,9 @@
       },
       "engines": {
         "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "remark-validate-links": "^13.0.1",
     "resize-observer-polyfill": "^1.5.1",
     "typescript": "^5.9.2",
-    "vite": "^7.2.7",
+    "vite": "^7.3.2",
     "vite-plugin-svgr": "^4.5.0",
     "vite-tsconfig-paths": "^6.1.1",
     "vitest": "^4.0.18"
@@ -191,11 +191,39 @@
     "cross-spawn": "^7.0.5",
     "form-data": "^4.0.4",
     "nanoid": "^3.3.9",
-    "esbuild": "^0.25.0",
+    "esbuild": "^0.27.0",
     "brace-expansion": "^2.0.2",
     "@messageformat/runtime": "^3.0.2",
     "glob": "^10.5.0",
     "js-yaml": "^4.1.1",
-    "mdast-util-to-hast": "^13.2.1"
+    "mdast-util-to-hast": "^13.2.1",
+    "micromatch": {
+      "picomatch": "^2.3.2"
+    },
+    "anymatch": {
+      "picomatch": "^2.3.2"
+    },
+    "readdirp": {
+      "picomatch": "^2.3.2"
+    },
+    "vite": {
+      "picomatch": "^4.0.4",
+      "yaml": "^2.8.3"
+    },
+    "tinyglobby": {
+      "picomatch": "^4.0.4"
+    },
+    "@rollup/pluginutils": {
+      "picomatch": "^4.0.4"
+    },
+    "vitest": {
+      "picomatch": "^4.0.4"
+    },
+    "cosmiconfig": {
+      "yaml": "^1.10.3"
+    },
+    "unified-engine": {
+      "yaml": "^2.8.3"
+    }
   }
 }

--- a/src/components/UploadGeojsonModal/UploadGeojsonModal.css
+++ b/src/components/UploadGeojsonModal/UploadGeojsonModal.css
@@ -15,6 +15,7 @@
   width: 600px;
   max-width: 80%;
   min-height: 280px;
+  max-height: min(90vh, 700px);
   background: var(--map-info-overlay-background);
   border: 1px solid var(--map-info-overlay-border);
   color: var(--map-info-overlay-color);
@@ -22,25 +23,38 @@
   position: relative;
   display: flex;
   flex-direction: column;
-  align-items: center;
-  justify-content: center;
+  align-items: stretch;
+  justify-content: flex-start;
+  gap: 12px;
   border-radius: var(--radius-sm);
+  overflow: hidden;
 }
 
 .uploadGeojsonModalTitle {
   font-size: 20px;
   font-weight: 700;
-  position: absolute;
-  top: 20px;
-  left: 20px;
+  margin-bottom: 6px;
+}
+
+.uploadGeojsonModalContent {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-height: 0;
+}
+
+.uploadGeojsonModalFooter {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: auto;
+  min-height: 44px;
 }
 
 .fileToUploadText {
-  position: absolute;
-  bottom: 25px;
-  left: 20px;
-  right: 140px;
-  width: calc(100% - 220px);
+  flex: 1;
+  min-width: 0;
   white-space: pre-wrap;
   white-space: -moz-pre-wrap;
   white-space: -pre-wrap;
@@ -49,11 +63,9 @@
 }
 
 .uploadGeojsonModalActionButtons {
-  position: absolute;
-  right: 20px;
   display: flex;
   flex-direction: row;
-  bottom: 10px;
+  flex-shrink: 0;
 }
 
 .uploadGeojsonModalActionButton {
@@ -119,4 +131,21 @@
 /* Keep this after Accept so Reject wins if both apply */
 .uploadGeojsonDropZoneReject {
   border-color: var(--validation-error-border);
+}
+
+.uploadGeojsonModalError {
+  margin: 10px 0;
+}
+
+.uploadGeojsonModalErrorSummary {
+  margin-bottom: 8px;
+}
+
+.uploadGeojsonModalErrorDetails {
+  max-height: 100px;
+  overflow-y: auto;
+  overflow-x: hidden;
+  white-space: pre-wrap;
+  word-break: break-word;
+  padding-right: 4px;
 }

--- a/src/components/UploadGeojsonModal/UploadGeojsonModal.jsx
+++ b/src/components/UploadGeojsonModal/UploadGeojsonModal.jsx
@@ -1,16 +1,40 @@
-import React, { useState } from 'react'
+import React, { useRef, useState } from 'react'
+import Alert from '@mui/material/Alert'
 import './UploadGeojsonModal.css'
 import { useDispatch } from 'react-redux'
-import { setshowUploadGeojsonModal } from '../../redux/slices/mainSlice'
+import {
+  setsearchGeojsonBoundary,
+  setshowUploadGeojsonModal
+} from '../../redux/slices/mainSlice'
 import { useDropzone } from 'react-dropzone'
-import { addUploadedGeojsonToMap, parseGeomUpload } from '../../utils/mapHelper'
+import {
+  addUploadedGeojsonToMap,
+  clearLayer,
+  parseGeomUpload
+} from '../../utils/mapHelper'
+import { newSearch, validateUploadedGeometry } from '../../utils/searchHelper'
 import { showApplicationAlert } from '../../utils/alertHelper'
 
 const UploadGeojsonModal = () => {
   const [fileData, setFileData] = useState(null)
+  const [serverErrorSummary, setServerErrorSummary] = useState(null)
+  const [serverErrorCode, setServerErrorCode] = useState(null)
+  const [serverErrorDetails, setServerErrorDetails] = useState(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const submissionInFlightRef = useRef(false)
+  const uploadAbortControllerRef = useRef(null)
   const dispatch = useDispatch()
 
+  const clearInlineServerError = () => {
+    setServerErrorSummary(null)
+    setServerErrorCode(null)
+    setServerErrorDetails(null)
+  }
+
   const handleFileDrop = (acceptedFiles) => {
+    clearInlineServerError()
+
+    if (!acceptedFiles || acceptedFiles.length === 0) return
     const file = acceptedFiles[0]
     if (file.size >= 100000) {
       setFileData(null)
@@ -59,34 +83,82 @@ const UploadGeojsonModal = () => {
     .join(' ')
 
   function onUploadGeojsonCancelClicked() {
+    uploadAbortControllerRef.current?.abort()
+    uploadAbortControllerRef.current = null
+    dispatch(setsearchGeojsonBoundary(null))
+    clearLayer('drawBoundsLayer')
     dispatch(setshowUploadGeojsonModal(false))
   }
 
   async function onUploadGeojsonAddClicked() {
-    let geoJsonData
+    if (submissionInFlightRef.current) return
+
+    submissionInFlightRef.current = true
+    setIsSubmitting(true)
+
+    clearInlineServerError()
+
     try {
-      geoJsonData = JSON.parse(fileData)
-    } catch (e) {
-      showApplicationAlert('warning', 'ERROR: JSON format invalid', 5000)
-      return
-    }
-    if (fileData) {
-      await parseGeomUpload(geoJsonData).then(
-        (response) => {
-          addUploadedGeojsonToMap(response)
-          dispatch(setshowUploadGeojsonModal(false))
-        },
-        // eslint-disable-next-line n/handle-callback-err
-        (error) => {
-          showApplicationAlert(
-            'warning',
-            'ERROR: ' + error.message.toString(),
-            5000
-          )
-        }
+      if (!fileData) {
+        showApplicationAlert('warning', 'No file selected', 5000)
+        return
+      }
+
+      let geoJsonData
+      try {
+        geoJsonData = JSON.parse(fileData)
+      } catch (e) {
+        showApplicationAlert('warning', 'ERROR: JSON format invalid', 5000)
+        return
+      }
+
+      const abortController = new AbortController()
+      uploadAbortControllerRef.current = abortController
+      const { signal } = abortController
+
+      const parsedGeom = await parseGeomUpload(geoJsonData)
+      const uploadValidationError = await validateUploadedGeometry(
+        parsedGeom,
+        signal
       )
-    } else {
-      showApplicationAlert('warning', 'No file selected', 5000)
+
+      if (signal.aborted) return
+
+      if (uploadValidationError) {
+        setServerErrorSummary(uploadValidationError.summary)
+        setServerErrorCode(uploadValidationError.code || null)
+        setServerErrorDetails(uploadValidationError.details || null)
+        return
+      }
+
+      addUploadedGeojsonToMap(parsedGeom)
+      const result = await newSearch({ signal })
+
+      if (signal.aborted) return
+
+      if (result && result.error) {
+        dispatch(setsearchGeojsonBoundary(null))
+        clearLayer('drawBoundsLayer')
+        setServerErrorSummary(result.summary)
+        setServerErrorCode(result.code || null)
+        setServerErrorDetails(result.details || null)
+        return
+      }
+
+      dispatch(setshowUploadGeojsonModal(false))
+    } catch (error) {
+      if (error?.name === 'AbortError') {
+        return
+      }
+      showApplicationAlert(
+        'warning',
+        'ERROR: ' + error.message.toString(),
+        5000
+      )
+    } finally {
+      submissionInFlightRef.current = false
+      setIsSubmitting(false)
+      uploadAbortControllerRef.current = null
     }
   }
 
@@ -95,33 +167,62 @@ const UploadGeojsonModal = () => {
       <div className="uploadGeojsonModalContainerBackground"></div>
       <div className="uploadGeojsonModalContainer">
         <span className="uploadGeojsonModalTitle">Upload Geojson File</span>
-        <div {...getRootProps({ className: dropzoneClass })} id="dropzone">
-          <p>
-            Drag and drop a GeoJSON file here or click to{' '}
-            <input
-              data-testid="testGeojsonFileUploadInput"
-              {...getInputProps({ accept: '.geojson, application/json' })}
-            />
-            browse
-          </p>
+        <div className="uploadGeojsonModalContent">
+          <div {...getRootProps({ className: dropzoneClass })} id="dropzone">
+            <p>
+              Drag and drop a GeoJSON file here or click to{' '}
+              <input
+                data-testid="testGeojsonFileUploadInput"
+                {...getInputProps({ accept: '.geojson, application/json' })}
+              />
+              browse
+            </p>
+          </div>
+          {serverErrorSummary && (
+            <div className="uploadGeojsonModalError">
+              <Alert severity="error">
+                <div className="uploadGeojsonModalErrorSummary">
+                  {serverErrorSummary}
+                </div>
+                {serverErrorDetails && (
+                  <div
+                    className="uploadGeojsonModalErrorDetails"
+                    data-testid="testUploadGeojsonErrorDetails"
+                  >
+                    {serverErrorCode
+                      ? `${serverErrorCode}: ${serverErrorDetails}`
+                      : serverErrorDetails}
+                  </div>
+                )}
+              </Alert>
+            </div>
+          )}
         </div>
-        {fileData ? (
-          <div className="fileToUploadText">{acceptedFileItems}</div>
-        ) : null}
-        <div className="uploadGeojsonModalActionButtons">
-          <button
-            className="uploadGeojsonModalActionButton"
-            onClick={onUploadGeojsonCancelClicked}
-          >
-            Cancel
-          </button>
-          <button
-            className={`uploadGeojsonModalActionButton${!fileData ? ' uploadGeojsonModalActionButtonDisabled' : ''}`}
-            onClick={onUploadGeojsonAddClicked}
-            disabled={!fileData}
-          >
-            Add
-          </button>
+        <div className="uploadGeojsonModalFooter">
+          {fileData ? (
+            <div className="fileToUploadText">{acceptedFileItems}</div>
+          ) : (
+            <div className="fileToUploadText"></div>
+          )}
+          <div className="uploadGeojsonModalActionButtons">
+            <button
+              className="uploadGeojsonModalActionButton"
+              onClick={onUploadGeojsonCancelClicked}
+            >
+              Cancel
+            </button>
+            <button
+              className={`uploadGeojsonModalActionButton${
+                !fileData || isSubmitting
+                  ? ' uploadGeojsonModalActionButtonDisabled'
+                  : ''
+              }`}
+              onClick={onUploadGeojsonAddClicked}
+              disabled={!fileData || isSubmitting}
+            >
+              Add
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/UploadGeojsonModal/UploadGeojsonModal.test.jsx
+++ b/src/components/UploadGeojsonModal/UploadGeojsonModal.test.jsx
@@ -5,9 +5,17 @@ import userEvent from '@testing-library/user-event'
 import UploadGeojsonModal from './UploadGeojsonModal'
 import { Provider } from 'react-redux'
 import { store } from '../../redux/store'
-import { setshowUploadGeojsonModal } from '../../redux/slices/mainSlice'
+import {
+  setsearchGeojsonBoundary,
+  setshowUploadGeojsonModal
+} from '../../redux/slices/mainSlice'
 import * as alertHelper from '../../utils/alertHelper'
 import * as mapHelper from '../../utils/mapHelper'
+import * as searchHelper from '../../utils/searchHelper'
+
+vi.mock('../../utils/alertHelper')
+vi.mock('../../utils/mapHelper')
+vi.mock('../../utils/searchHelper')
 
 describe('UploadGeojsonModal', () => {
   const user = userEvent.setup()
@@ -29,10 +37,6 @@ describe('UploadGeojsonModal', () => {
     })
   })
   describe('when upload button is clicked', () => {
-    beforeEach(() => {
-      vi.mock('../../utils/alertHelper')
-      vi.mock('../../utils/mapHelper')
-    })
     afterEach(() => {
       vi.resetAllMocks()
     })
@@ -100,7 +104,7 @@ describe('UploadGeojsonModal', () => {
       expect(spyaddUploadedGeojsonToMap).not.toHaveBeenCalled()
       expect(store.getState().mainSlice.showUploadGeojsonModal).toBeTruthy()
     })
-    it('should call addUploadedGeojsonToMap and close modal if parseGeomUpload does not error', async () => {
+    it('should call addUploadedGeojsonToMap and close modal if parseGeomUpload and newSearch do not error', async () => {
       const spyshowApplicationAlert = vi.spyOn(
         alertHelper,
         'showApplicationAlert'
@@ -110,6 +114,10 @@ describe('UploadGeojsonModal', () => {
         'addUploadedGeojsonToMap'
       )
       mapHelper.parseGeomUpload.mockResolvedValueOnce('parsed geojson')
+      vi.spyOn(searchHelper, 'validateUploadedGeometry').mockResolvedValueOnce(
+        undefined
+      )
+      vi.spyOn(searchHelper, 'newSearch').mockResolvedValueOnce(undefined)
 
       store.dispatch(setshowUploadGeojsonModal(true))
       setup()
@@ -134,6 +142,323 @@ describe('UploadGeojsonModal', () => {
       await user.click(cancelButton)
       expect(spyshowApplicationAlert).not.toHaveBeenCalled()
       expect(spyaddUploadedGeojsonToMap).toHaveBeenCalledWith('parsed geojson')
+      expect(searchHelper.newSearch).toHaveBeenCalledWith(
+        expect.objectContaining({ signal: expect.any(AbortSignal) })
+      )
+      expect(store.getState().mainSlice.showUploadGeojsonModal).toBeFalsy()
+    })
+
+    it('clears AOI and draw layer when newSearch returns structured error', async () => {
+      const spyClearLayer = vi.spyOn(mapHelper, 'clearLayer')
+      mapHelper.parseGeomUpload.mockResolvedValueOnce('parsed geojson')
+      vi.spyOn(searchHelper, 'validateUploadedGeometry').mockResolvedValueOnce(
+        undefined
+      )
+      vi.spyOn(searchHelper, 'newSearch').mockResolvedValueOnce({
+        error: true,
+        summary: 'Error Fetching Search Results',
+        code: 'BadRequest',
+        details: 'fail'
+      })
+      mapHelper.addUploadedGeojsonToMap.mockImplementationOnce(() => {
+        store.dispatch(
+          setsearchGeojsonBoundary({
+            type: 'Feature',
+            geometry: { type: 'Point', coordinates: [2, 2] },
+            properties: {}
+          })
+        )
+      })
+
+      store.dispatch(setshowUploadGeojsonModal(true))
+      setup()
+
+      const geojson = JSON.stringify({
+        type: 'Feature',
+        geometry: {
+          type: 'Point',
+          coordinates: [0, 0]
+        },
+        properties: {
+          name: 'My Point'
+        }
+      })
+
+      const file = new File([geojson], 'test.geojson', {
+        type: 'application/json'
+      })
+      const input = screen.getByTestId('testGeojsonFileUploadInput')
+      await waitFor(async () =>
+        fireEvent.change(input, { target: { files: [file] } })
+      )
+
+      const addButton = screen.getByRole('button', { name: /add/i })
+      await user.click(addButton)
+
+      expect(store.getState().mainSlice.searchGeojsonBoundary).toBeNull()
+      expect(spyClearLayer).toHaveBeenCalledWith('drawBoundsLayer')
+      expect(
+        screen.getByText('Error Fetching Search Results')
+      ).toBeInTheDocument()
+      expect(store.getState().mainSlice.showUploadGeojsonModal).toBeTruthy()
+    })
+
+    it('should show inline STAC error and keep modal open when upload validation returns error object', async () => {
+      mapHelper.parseGeomUpload.mockResolvedValueOnce('parsed geojson')
+      vi.spyOn(searchHelper, 'validateUploadedGeometry').mockResolvedValueOnce({
+        error: true,
+        code: 'BadRequest',
+        summary: 'Unable to search the uploaded area',
+        details: 'geo coordinates must be numbers'
+      })
+
+      store.dispatch(setshowUploadGeojsonModal(true))
+      setup()
+
+      const geojson = JSON.stringify({
+        type: 'Feature',
+        geometry: {
+          type: 'Point',
+          coordinates: [0, 0]
+        },
+        properties: {
+          name: 'My Point'
+        }
+      })
+
+      const file = new File([geojson], 'test.geojson', {
+        type: 'application/json'
+      })
+      const input = screen.getByTestId('testGeojsonFileUploadInput')
+      await waitFor(async () =>
+        fireEvent.change(input, { target: { files: [file] } })
+      )
+
+      const addButton = screen.getByRole('button', { name: /add/i })
+      await user.click(addButton)
+
+      expect(
+        screen.getByText('Unable to search the uploaded area')
+      ).toBeInTheDocument()
+      expect(
+        screen.getByText('BadRequest: geo coordinates must be numbers')
+      ).toBeInTheDocument()
+      expect(screen.getByTestId('testUploadGeojsonErrorDetails')).toHaveClass(
+        'uploadGeojsonModalErrorDetails'
+      )
+      expect(mapHelper.addUploadedGeojsonToMap).not.toHaveBeenCalled()
+      expect(store.getState().mainSlice.showUploadGeojsonModal).toBeTruthy()
+    })
+
+    it('keeps error summary visible and renders long details in dedicated container', async () => {
+      mapHelper.parseGeomUpload.mockResolvedValueOnce('parsed geojson')
+      const longDetails = `very long server message ${'x'.repeat(500)}`
+      vi.spyOn(searchHelper, 'validateUploadedGeometry').mockResolvedValueOnce({
+        error: true,
+        code: 'BadRequest',
+        summary: 'Unable to search the uploaded area',
+        details: longDetails
+      })
+
+      store.dispatch(setshowUploadGeojsonModal(true))
+      setup()
+
+      const geojson = JSON.stringify({
+        type: 'Feature',
+        geometry: {
+          type: 'Point',
+          coordinates: [0, 0]
+        },
+        properties: {
+          name: 'My Point'
+        }
+      })
+
+      const file = new File([geojson], 'test.geojson', {
+        type: 'application/json'
+      })
+      const input = screen.getByTestId('testGeojsonFileUploadInput')
+      await waitFor(async () =>
+        fireEvent.change(input, { target: { files: [file] } })
+      )
+
+      const addButton = screen.getByRole('button', { name: /add/i })
+      await user.click(addButton)
+
+      expect(
+        screen.getByText('Unable to search the uploaded area')
+      ).toBeInTheDocument()
+
+      const detailsContainer = screen.getByTestId(
+        'testUploadGeojsonErrorDetails'
+      )
+      expect(detailsContainer).toHaveClass('uploadGeojsonModalErrorDetails')
+      expect(detailsContainer).toHaveTextContent(`BadRequest: ${longDetails}`)
+    })
+
+    it('clears inline STAC errors when a new (still-accepted) file drop fails validation', async () => {
+      mapHelper.parseGeomUpload.mockResolvedValueOnce('parsed geojson')
+      vi.spyOn(searchHelper, 'validateUploadedGeometry').mockResolvedValueOnce({
+        error: true,
+        code: 'BadRequest',
+        summary: 'Unable to search the uploaded area',
+        details: 'geo coordinates must be numbers'
+      })
+
+      store.dispatch(setshowUploadGeojsonModal(true))
+      setup()
+
+      const geojson = JSON.stringify({
+        type: 'Feature',
+        geometry: {
+          type: 'Point',
+          coordinates: [0, 0]
+        },
+        properties: {
+          name: 'My Point'
+        }
+      })
+
+      const validFile = new File([geojson], 'test.geojson', {
+        type: 'application/json'
+      })
+      const input = screen.getByTestId('testGeojsonFileUploadInput')
+
+      await waitFor(async () =>
+        fireEvent.change(input, { target: { files: [validFile] } })
+      )
+
+      const addButton = screen.getByRole('button', { name: /add/i })
+      await user.click(addButton)
+
+      expect(
+        screen.getByText('Unable to search the uploaded area')
+      ).toBeInTheDocument()
+
+      const bigString = 'a'.repeat(100001)
+      const bigFile = new File([bigString], 'test.geojson', {
+        type: 'application/json'
+      })
+
+      await waitFor(async () =>
+        fireEvent.change(input, { target: { files: [bigFile] } })
+      )
+
+      expect(
+        screen.queryByText('Unable to search the uploaded area')
+      ).not.toBeInTheDocument()
+    })
+
+    it('only calls newSearch once when Add is clicked twice quickly', async () => {
+      let resolveSearch
+      const searchPromise = new Promise((resolve) => {
+        resolveSearch = resolve
+      })
+
+      mapHelper.parseGeomUpload.mockResolvedValueOnce('parsed geojson')
+      vi.spyOn(searchHelper, 'validateUploadedGeometry').mockResolvedValueOnce(
+        undefined
+      )
+      vi.spyOn(searchHelper, 'newSearch').mockReturnValue(searchPromise)
+
+      store.dispatch(setshowUploadGeojsonModal(true))
+      setup()
+
+      const geojson = JSON.stringify({
+        type: 'Feature',
+        geometry: {
+          type: 'Point',
+          coordinates: [0, 0]
+        },
+        properties: {
+          name: 'My Point'
+        }
+      })
+
+      const file = new File([geojson], 'test.geojson', {
+        type: 'application/json'
+      })
+      const input = screen.getByTestId('testGeojsonFileUploadInput')
+
+      await waitFor(async () =>
+        fireEvent.change(input, { target: { files: [file] } })
+      )
+
+      const addButton = screen.getByRole('button', { name: /add/i })
+
+      await user.click(addButton)
+      await user.click(addButton)
+
+      expect(searchHelper.newSearch).toHaveBeenCalledTimes(1)
+
+      resolveSearch(undefined)
+      await waitFor(() =>
+        expect(store.getState().mainSlice.showUploadGeojsonModal).toBeFalsy()
+      )
+    })
+
+    it('keeps Cancel enabled while upload is submitting', async () => {
+      let resolveSearch
+      const searchPromise = new Promise((resolve) => {
+        resolveSearch = resolve
+      })
+
+      mapHelper.parseGeomUpload.mockResolvedValueOnce('parsed geojson')
+      vi.spyOn(searchHelper, 'validateUploadedGeometry').mockResolvedValueOnce(
+        undefined
+      )
+      vi.spyOn(searchHelper, 'newSearch').mockReturnValue(searchPromise)
+
+      store.dispatch(setshowUploadGeojsonModal(true))
+      setup()
+
+      const geojson = JSON.stringify({
+        type: 'Feature',
+        geometry: {
+          type: 'Point',
+          coordinates: [0, 0]
+        },
+        properties: {
+          name: 'My Point'
+        }
+      })
+
+      const file = new File([geojson], 'test.geojson', {
+        type: 'application/json'
+      })
+      const input = screen.getByTestId('testGeojsonFileUploadInput')
+      await waitFor(async () =>
+        fireEvent.change(input, { target: { files: [file] } })
+      )
+
+      const addButton = screen.getByRole('button', { name: /add/i })
+      await user.click(addButton)
+
+      const cancelButton = screen.getByRole('button', { name: /cancel/i })
+      expect(cancelButton).not.toBeDisabled()
+      await user.click(cancelButton)
+      expect(store.getState().mainSlice.showUploadGeojsonModal).toBeFalsy()
+
+      resolveSearch(undefined)
+    })
+
+    it('clears upload AOI state when cancel is clicked', async () => {
+      const spyClearLayer = vi.spyOn(mapHelper, 'clearLayer')
+      store.dispatch(
+        setsearchGeojsonBoundary({
+          type: 'Feature',
+          geometry: { type: 'Point', coordinates: [0, 0] },
+          properties: {}
+        })
+      )
+      store.dispatch(setshowUploadGeojsonModal(true))
+      setup()
+
+      const cancelButton = screen.getByRole('button', { name: /cancel/i })
+      await user.click(cancelButton)
+
+      expect(store.getState().mainSlice.searchGeojsonBoundary).toBeNull()
+      expect(spyClearLayer).toHaveBeenCalledWith('drawBoundsLayer')
       expect(store.getState().mainSlice.showUploadGeojsonModal).toBeFalsy()
     })
   })

--- a/src/services/get-aggregate-service.js
+++ b/src/services/get-aggregate-service.js
@@ -86,6 +86,7 @@ export async function AggregateSearchService(
     }
 
     addDataToLayer(gridFromJson, 'searchResultsLayer', options, true)
+    return undefined
   } catch (error) {
     if (error?.name === 'AbortError') {
       return undefined

--- a/src/services/get-aggregate-service.js
+++ b/src/services/get-aggregate-service.js
@@ -6,76 +6,94 @@ import {
   gridCodeLayerStyle
 } from '../utils/mapHelper'
 import { mapHexGridFromJson, mapGridCodeFromJson } from '../utils/searchHelper'
-import { appendStacHeaderCookies } from '../utils/stacRequest'
+import { buildStacRequestHeaders } from '../utils/stacRequest'
+import {
+  normalizeStacErrorResponse,
+  normalizeStacNetworkError
+} from '../utils/stacErrorHelper'
 
-export async function AggregateSearchService(searchParams, gridType) {
-  const requestHeaders = new Headers()
-  const JWT = localStorage.getItem('APP_AUTH_TOKEN')
-  const isSTACTokenAuthEnabled =
-    store.getState().mainSlice.appConfig.APP_TOKEN_AUTH_ENABLED ?? false
-  if (JWT && isSTACTokenAuthEnabled) {
-    requestHeaders.append('Authorization', `Bearer ${JWT}`)
+const DEFAULT_AGGREGATE_ERROR_SUMMARY =
+  'Error Fetching Aggregate Search Results'
+
+export async function AggregateSearchService(
+  searchParams,
+  gridType,
+  contextLabel = DEFAULT_AGGREGATE_ERROR_SUMMARY,
+  signal
+) {
+  const requestHeaders = buildStacRequestHeaders()
+
+  const fetchOptions = {
+    credentials:
+      store.getState().mainSlice.appConfig.FETCH_CREDENTIALS || 'same-origin',
+    headers: requestHeaders
   }
-  appendStacHeaderCookies(requestHeaders)
+  if (signal) {
+    fetchOptions.signal = signal
+  }
 
-  await fetch(
-    `${
-      store.getState().mainSlice.appConfig.STAC_API_URL
-    }/aggregate?${searchParams}`,
-    {
-      credentials:
-        store.getState().mainSlice.appConfig.FETCH_CREDENTIALS || 'same-origin',
-      headers: requestHeaders
+  try {
+    const response = await fetch(
+      `${
+        store.getState().mainSlice.appConfig.STAC_API_URL
+      }/aggregate?${searchParams}`,
+      fetchOptions
+    )
+
+    if (!response.ok) {
+      const normalizedError = await normalizeStacErrorResponse(
+        response,
+        contextLabel
+      )
+      console.error(contextLabel, normalizedError)
+      return normalizedError
     }
-  )
-    .then((response) => {
-      if (response.ok) {
-        return response.json()
-      }
-      throw new Error()
-    })
-    .then((json) => {
-      let gridFromJson
-      let options
-      if (gridType === 'hex') {
-        gridFromJson = mapHexGridFromJson(json)
-        store.dispatch(setSearchResults(gridFromJson))
-        options = buildHexGridLayerOptions(gridFromJson.properties.largestRatio)
-      } else {
-        gridFromJson = mapGridCodeFromJson(json)
-        store.dispatch(setSearchResults(gridFromJson))
-        options = {
-          style: gridCodeLayerStyle,
-          onEachFeature: function (feature, layer) {
-            const scenes = feature.properties.frequency > 1 ? 'scenes' : 'scene'
-            layer.bindTooltip(
-              `${feature.properties.frequency.toString()} <span>${scenes}</span>`,
-              {
-                permanent: false,
-                direction: 'top',
-                className: 'tooltip_style',
-                interactive: false
+
+    const json = await response.json()
+
+    let gridFromJson
+    let options
+    if (gridType === 'hex') {
+      gridFromJson = mapHexGridFromJson(json)
+      store.dispatch(setSearchResults(gridFromJson))
+      options = buildHexGridLayerOptions(gridFromJson.properties.largestRatio)
+    } else {
+      gridFromJson = mapGridCodeFromJson(json)
+      store.dispatch(setSearchResults(gridFromJson))
+      options = {
+        style: gridCodeLayerStyle,
+        onEachFeature: function (feature, layer) {
+          const scenes = feature.properties.frequency > 1 ? 'scenes' : 'scene'
+          layer.bindTooltip(
+            `${feature.properties.frequency.toString()} <span>${scenes}</span>`,
+            {
+              permanent: false,
+              direction: 'top',
+              className: 'tooltip_style',
+              interactive: false
+            }
+          )
+          layer.on('mouseout', function (e) {
+            const map = store.getState().mainSlice.map
+            map.eachLayer(function (layer) {
+              if (layer.getTooltip()) {
+                layer.closeTooltip()
               }
-            )
-            layer.on('mouseout', function (e) {
-              const map = store.getState().mainSlice.map
-              map.eachLayer(function (layer) {
-                if (layer.getTooltip()) {
-                  layer.closeTooltip()
-                }
-              })
             })
-          }
+          })
         }
       }
+    }
 
-      store.dispatch(setSearchLoading(false))
-      addDataToLayer(gridFromJson, 'searchResultsLayer', options, true)
-    })
-    .catch((error) => {
-      store.dispatch(setSearchLoading(false))
-      const message = 'Error Fetching Aggregate Search Results'
-      // log full error for diagnosing client side errors if needed
-      console.error(message, error)
-    })
+    addDataToLayer(gridFromJson, 'searchResultsLayer', options, true)
+  } catch (error) {
+    if (error?.name === 'AbortError') {
+      return undefined
+    }
+    const normalizedError = normalizeStacNetworkError(error, contextLabel)
+    console.error(contextLabel, normalizedError)
+    return normalizedError
+  } finally {
+    store.dispatch(setSearchLoading(false))
+  }
 }

--- a/src/services/get-aggregate-service.test.js
+++ b/src/services/get-aggregate-service.test.js
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { AggregateSearchService } from './get-aggregate-service'
+import { store } from '../redux/store'
+import { setappConfig } from '../redux/slices/mainSlice'
+
+const DEFAULT_AGGREGATE_ERROR_SUMMARY =
+  'Error Fetching Aggregate Search Results'
+
+global.fetch = vi.fn()
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  store.dispatch(
+    setappConfig({
+      STAC_API_URL: 'https://stac-api.example.com',
+      APP_TOKEN_AUTH_ENABLED: false,
+      FETCH_CREDENTIALS: 'same-origin'
+    })
+  )
+  localStorage.clear()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('AggregateSearchService error handling', () => {
+  it('returns normalized error for non-OK JSON and unquotes description', async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {})
+    const searchParams = 'collections=demo&limit=10'
+    const errorBody = {
+      code: 'BadRequest',
+      description: '"geo coordinates must be numbers"'
+    }
+
+    global.fetch.mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      text: async () => JSON.stringify(errorBody)
+    })
+
+    const result = await AggregateSearchService(searchParams, 'hex')
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        error: true,
+        status: 400,
+        code: errorBody.code,
+        summary: DEFAULT_AGGREGATE_ERROR_SUMMARY,
+        details: 'geo coordinates must be numbers'
+      })
+    )
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'Error Fetching Aggregate Search Results',
+      expect.objectContaining({
+        error: true,
+        status: 400
+      })
+    )
+  })
+
+  it('returns normalized network error when fetch rejects', async () => {
+    const searchParams = 'collections=demo&limit=10'
+
+    global.fetch.mockRejectedValueOnce(new Error('Network error'))
+
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {})
+    const result = await AggregateSearchService(searchParams, 'hex')
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        error: true,
+        status: null,
+        code: null,
+        summary: DEFAULT_AGGREGATE_ERROR_SUMMARY,
+        details: 'Network error'
+      })
+    )
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'Error Fetching Aggregate Search Results',
+      expect.objectContaining({
+        error: true,
+        status: null
+      })
+    )
+  })
+
+  it('returns undefined on fetch abort without normalizing', async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {})
+    const searchParams = 'collections=demo&limit=10'
+    const abortError = Object.assign(new Error('Aborted'), {
+      name: 'AbortError'
+    })
+
+    global.fetch.mockRejectedValueOnce(abortError)
+
+    const controller = new AbortController()
+    const result = await AggregateSearchService(
+      searchParams,
+      'hex',
+      DEFAULT_AGGREGATE_ERROR_SUMMARY,
+      controller.signal
+    )
+
+    expect(result).toBeUndefined()
+    expect(consoleErrorSpy).not.toHaveBeenCalled()
+  })
+})

--- a/src/services/get-aggregate-service.test.js
+++ b/src/services/get-aggregate-service.test.js
@@ -2,6 +2,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { AggregateSearchService } from './get-aggregate-service'
 import { store } from '../redux/store'
 import { setappConfig } from '../redux/slices/mainSlice'
+import * as searchHelper from '../utils/searchHelper'
+import * as mapHelper from '../utils/mapHelper'
 
 const DEFAULT_AGGREGATE_ERROR_SUMMARY =
   'Error Fetching Aggregate Search Results'
@@ -25,6 +27,40 @@ afterEach(() => {
 })
 
 describe('AggregateSearchService error handling', () => {
+  it('returns undefined on successful hex aggregate and still updates map layer', async () => {
+    const searchParams = 'collections=demo&limit=10'
+    const responseJson = { aggregations: [] }
+    const mappedGrid = {
+      type: 'FeatureCollection',
+      features: [],
+      properties: { largestRatio: 1 }
+    }
+    const layerOptions = { style: {} }
+
+    vi.spyOn(searchHelper, 'mapHexGridFromJson').mockReturnValue(mappedGrid)
+    vi.spyOn(mapHelper, 'buildHexGridLayerOptions').mockReturnValue(
+      layerOptions
+    )
+    const addDataSpy = vi
+      .spyOn(mapHelper, 'addDataToLayer')
+      .mockImplementation(() => {})
+
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => responseJson
+    })
+
+    const result = await AggregateSearchService(searchParams, 'hex')
+
+    expect(result).toBeUndefined()
+    expect(addDataSpy).toHaveBeenCalledWith(
+      mappedGrid,
+      'searchResultsLayer',
+      layerOptions,
+      true
+    )
+  })
+
   it('returns normalized error for non-OK JSON and unquotes description', async () => {
     const consoleErrorSpy = vi
       .spyOn(console, 'error')

--- a/src/services/get-search-service.js
+++ b/src/services/get-search-service.js
@@ -12,18 +12,24 @@ import {
   setpaginationHistory
 } from '../redux/slices/mainSlice'
 import { addDataToLayer, footprintLayerStyle } from '../utils/mapHelper'
-import { appendStacHeaderCookies } from '../utils/stacRequest'
+import { buildStacRequestHeaders } from '../utils/stacRequest'
 import { DEFAULT_API_MAX_ITEMS } from '../components/defaults'
+import {
+  normalizeStacErrorResponse,
+  normalizeStacNetworkError
+} from '../utils/stacErrorHelper'
 
-export async function SearchService(searchParams, typeOfSearch) {
-  const requestHeaders = new Headers()
-  const JWT = localStorage.getItem('APP_AUTH_TOKEN')
-  const isSTACTokenAuthEnabled =
-    store.getState().mainSlice.appConfig.APP_TOKEN_AUTH_ENABLED ?? false
-  if (JWT && isSTACTokenAuthEnabled) {
-    requestHeaders.append('Authorization', `Bearer ${JWT}`)
-  }
-  appendStacHeaderCookies(requestHeaders)
+const DEFAULT_SEARCH_ERROR_SUMMARY = 'Error Fetching Search Results'
+const DEFAULT_MOSAIC_TOP_ITEMS_ERROR_SUMMARY =
+  'Error fetching top items for mosaic'
+
+export async function SearchService(
+  searchParams,
+  typeOfSearch,
+  contextLabel = DEFAULT_SEARCH_ERROR_SUMMARY,
+  signal
+) {
+  const requestHeaders = buildStacRequestHeaders()
 
   const stacApiUrl = `${
     store.getState().mainSlice.appConfig.STAC_API_URL
@@ -32,72 +38,84 @@ export async function SearchService(searchParams, typeOfSearch) {
   console.log('STAC API Search Request:', stacApiUrl)
   console.log('Search Parameters:', searchParams)
 
-  await fetch(stacApiUrl, {
+  const fetchOptions = {
     credentials:
       store.getState().mainSlice.appConfig.FETCH_CREDENTIALS || 'same-origin',
     headers: requestHeaders
-  })
-    .then((response) => {
-      if (response.ok) {
-        return response.json()
+  }
+  if (signal) {
+    fetchOptions.signal = signal
+  }
+
+  try {
+    const response = await fetch(stacApiUrl, fetchOptions)
+
+    if (!response.ok) {
+      const normalizedError = await normalizeStacErrorResponse(
+        response,
+        contextLabel
+      )
+      console.error(contextLabel, normalizedError)
+      return normalizedError
+    }
+
+    const json = await response.json()
+
+    if (typeOfSearch === 'scene') {
+      store.dispatch(setSearchResults(json))
+      store.dispatch(setmappedScenes(json.features))
+
+      // Extract pagination metadata
+      const nextLink = json.links?.find((link) => link.rel === 'next')
+      const prevLink = json.links?.find((link) => link.rel === 'prev')
+
+      store.dispatch(setpaginationNextLink(nextLink?.href || null))
+      store.dispatch(setpaginationPrevLink(prevLink?.href || null))
+      store.dispatch(setcurrentPage(1))
+
+      // Initialize pagination history with the current search URL (page 1)
+      const currentUrl = `${store.getState().mainSlice.appConfig.STAC_API_URL}/search?${searchParams}`
+      store.dispatch(setpaginationHistory([{ page: 1, url: currentUrl }]))
+
+      // Calculate total pages if we have numberMatched
+      if (json.context?.matched || json.numberMatched) {
+        const totalItems = json.context?.matched || json.numberMatched
+        const limit =
+          store.getState().mainSlice.appConfig.API_MAX_ITEMS ||
+          DEFAULT_API_MAX_ITEMS
+        const totalPages = Math.ceil(totalItems / limit)
+        store.dispatch(settotalPages(totalPages))
       }
-      throw new Error()
-    })
-    .then((json) => {
-      if (typeOfSearch === 'scene') {
-        store.dispatch(setSearchResults(json))
-        store.dispatch(setmappedScenes(json.features))
 
-        // Extract pagination metadata
-        const nextLink = json.links?.find((link) => link.rel === 'next')
-        const prevLink = json.links?.find((link) => link.rel === 'prev')
-
-        store.dispatch(setpaginationNextLink(nextLink?.href || null))
-        store.dispatch(setpaginationPrevLink(prevLink?.href || null))
-        store.dispatch(setcurrentPage(1))
-
-        // Initialize pagination history with the current search URL (page 1)
-        const currentUrl = `${store.getState().mainSlice.appConfig.STAC_API_URL}/search?${searchParams}`
-        store.dispatch(setpaginationHistory([{ page: 1, url: currentUrl }]))
-
-        // Calculate total pages if we have numberMatched
-        if (json.context?.matched || json.numberMatched) {
-          const totalItems = json.context?.matched || json.numberMatched
-          const limit =
-            store.getState().mainSlice.appConfig.API_MAX_ITEMS ||
-            DEFAULT_API_MAX_ITEMS
-          const totalPages = Math.ceil(totalItems / limit)
-          store.dispatch(settotalPages(totalPages))
-        }
-
-        const options = {
-          style: footprintLayerStyle
-        }
-        store.dispatch(setSearchLoading(false))
-        addDataToLayer(json, 'searchResultsLayer', options, true)
-      } else {
-        store.dispatch(setSearchLoading(false))
-        store.dispatch(setClickResults(json.features))
-        store.dispatch(settabSelected('details'))
+      const options = {
+        style: footprintLayerStyle
       }
-    })
-    .catch((error) => {
-      store.dispatch(setSearchLoading(false))
-      const message = 'Error Fetching Search Results'
-      // log full error for diagnosing client side errors if needed
-      console.error(message, error)
-    })
+      addDataToLayer(json, 'searchResultsLayer', options, true)
+      return undefined
+    }
+
+    store.dispatch(setClickResults(json.features))
+    store.dispatch(settabSelected('details'))
+    return undefined
+  } catch (error) {
+    if (error?.name === 'AbortError') {
+      return undefined
+    }
+    const normalizedError = normalizeStacNetworkError(error, contextLabel)
+    console.error(contextLabel, normalizedError)
+    return normalizedError
+  } finally {
+    store.dispatch(setSearchLoading(false))
+  }
 }
 
-export async function fetchTopItemsForMosaic(searchParams, limit) {
-  const requestHeaders = new Headers()
-  const JWT = localStorage.getItem('APP_AUTH_TOKEN')
-  const isSTACTokenAuthEnabled =
-    store.getState().mainSlice.appConfig.APP_TOKEN_AUTH_ENABLED ?? false
-  if (JWT && isSTACTokenAuthEnabled) {
-    requestHeaders.append('Authorization', `Bearer ${JWT}`)
-  }
-  appendStacHeaderCookies(requestHeaders)
+export async function fetchTopItemsForMosaic(
+  searchParams,
+  limit,
+  contextLabel = DEFAULT_MOSAIC_TOP_ITEMS_ERROR_SUMMARY,
+  signal
+) {
+  const requestHeaders = buildStacRequestHeaders()
 
   const effectiveLimit = Math.max(1, limit || 1)
 
@@ -105,25 +123,46 @@ export async function fetchTopItemsForMosaic(searchParams, limit) {
     store.getState().mainSlice.appConfig.STAC_API_URL
   }/search?${searchParams}`
 
-  const response = await fetch(stacApiUrl, {
+  const fetchOptions = {
     credentials:
       store.getState().mainSlice.appConfig.FETCH_CREDENTIALS || 'same-origin',
     headers: requestHeaders
-  })
-
-  if (!response.ok) {
-    throw new Error(
-      `Error fetching top items for mosaic (status ${response.status})`
-    )
+  }
+  if (signal) {
+    fetchOptions.signal = signal
   }
 
-  const json = await response.json()
-  const itemIds = Array.isArray(json.features)
-    ? json.features.map((feature) => feature.id).filter(Boolean)
-    : []
+  try {
+    const response = await fetch(stacApiUrl, fetchOptions)
 
-  return {
-    itemIds,
-    effectiveLimit: Math.min(effectiveLimit, itemIds.length)
+    if (!response.ok) {
+      const normalizedError = await normalizeStacErrorResponse(
+        response,
+        contextLabel
+      )
+      throw normalizedError
+    }
+
+    const json = await response.json()
+    const itemIds = Array.isArray(json.features)
+      ? json.features.map((feature) => feature.id).filter(Boolean)
+      : []
+
+    return {
+      itemIds,
+      effectiveLimit: Math.min(effectiveLimit, itemIds.length)
+    }
+  } catch (error) {
+    if (error?.name === 'AbortError') {
+      throw error
+    }
+    if (error && error.error) {
+      console.error(contextLabel, error)
+      throw error
+    }
+
+    const normalizedError = normalizeStacNetworkError(error, contextLabel)
+    console.error(contextLabel, normalizedError)
+    throw normalizedError
   }
 }

--- a/src/services/get-search-service.test.js
+++ b/src/services/get-search-service.test.js
@@ -1,0 +1,208 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { SearchService, fetchTopItemsForMosaic } from './get-search-service'
+import { store } from '../redux/store'
+import { setappConfig } from '../redux/slices/mainSlice'
+
+const DEFAULT_SEARCH_ERROR_SUMMARY = 'Error Fetching Search Results'
+const DEFAULT_MOSAIC_TOP_ITEMS_ERROR_SUMMARY =
+  'Error fetching top items for mosaic'
+
+global.fetch = vi.fn()
+
+const mockStacApiUrl = 'https://stac-api.example.com'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  store.dispatch(
+    setappConfig({
+      STAC_API_URL: mockStacApiUrl,
+      APP_TOKEN_AUTH_ENABLED: false,
+      FETCH_CREDENTIALS: 'same-origin'
+    })
+  )
+  localStorage.clear()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('SearchService error handling', () => {
+  it('returns normalized error object for non-OK JSON error response', async () => {
+    const searchParams = 'collections=demo&limit=10'
+    const errorBody = {
+      code: 'InvalidQuery',
+      message: 'Invalid geometry',
+      detail: 'Geometry must be within valid bounds'
+    }
+
+    global.fetch.mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      text: async () => JSON.stringify(errorBody)
+    })
+
+    const result = await SearchService(searchParams, 'scene')
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        error: true,
+        status: 400,
+        code: errorBody.code,
+        summary: DEFAULT_SEARCH_ERROR_SUMMARY,
+        details: errorBody.message
+      })
+    )
+  })
+
+  it('returns normalized error object for non-OK plain text error response', async () => {
+    const searchParams = 'collections=demo&limit=10'
+    const bodyText = 'Bad Request'
+
+    global.fetch.mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      text: async () => bodyText
+    })
+
+    const result = await SearchService(searchParams, 'scene')
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        error: true,
+        status: 400,
+        summary: DEFAULT_SEARCH_ERROR_SUMMARY,
+        code: null,
+        details: bodyText
+      })
+    )
+  })
+
+  it('returns normalized network error when fetch rejects', async () => {
+    const searchParams = 'collections=demo&limit=10'
+
+    global.fetch.mockRejectedValueOnce(new Error('Network error'))
+
+    const result = await SearchService(searchParams, 'scene')
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        error: true,
+        status: null,
+        summary: DEFAULT_SEARCH_ERROR_SUMMARY,
+        code: null,
+        details: 'Network error'
+      })
+    )
+  })
+
+  it('returns undefined on fetch abort without logging normalized error', async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {})
+    const searchParams = 'collections=demo&limit=10'
+    const abortError = Object.assign(new Error('Aborted'), {
+      name: 'AbortError'
+    })
+
+    global.fetch.mockRejectedValueOnce(abortError)
+
+    const controller = new AbortController()
+    const result = await SearchService(
+      searchParams,
+      'scene',
+      DEFAULT_SEARCH_ERROR_SUMMARY,
+      controller.signal
+    )
+
+    expect(result).toBeUndefined()
+    expect(consoleErrorSpy).not.toHaveBeenCalledWith(
+      DEFAULT_SEARCH_ERROR_SUMMARY,
+      expect.objectContaining({ error: true })
+    )
+  })
+})
+
+describe('fetchTopItemsForMosaic error handling', () => {
+  it('throws normalized error object for non-OK JSON error response', async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {})
+    const searchParams = 'collections=demo&limit=10'
+    const errorBody = {
+      code: 'InvalidAggregate',
+      message: 'Invalid aggregate request'
+    }
+
+    global.fetch.mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      text: async () => JSON.stringify(errorBody)
+    })
+
+    await expect(fetchTopItemsForMosaic(searchParams, 5)).rejects.toEqual(
+      expect.objectContaining({
+        error: true,
+        status: 400,
+        code: errorBody.code,
+        summary: DEFAULT_MOSAIC_TOP_ITEMS_ERROR_SUMMARY,
+        details: errorBody.message
+      })
+    )
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'Error fetching top items for mosaic',
+      expect.objectContaining({
+        error: true,
+        status: 400
+      })
+    )
+  })
+
+  it('throws normalized network error when fetch rejects', async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {})
+    const searchParams = 'collections=demo&limit=10'
+
+    global.fetch.mockRejectedValueOnce(new Error('Network error'))
+
+    await expect(fetchTopItemsForMosaic(searchParams, 5)).rejects.toEqual(
+      expect.objectContaining({
+        error: true,
+        status: null,
+        summary: DEFAULT_MOSAIC_TOP_ITEMS_ERROR_SUMMARY,
+        details: 'Network error'
+      })
+    )
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'Error fetching top items for mosaic',
+      expect.objectContaining({
+        error: true,
+        status: null
+      })
+    )
+  })
+
+  it('rethrows AbortError without normalizing', async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {})
+    const searchParams = 'collections=demo&limit=10'
+    const abortError = Object.assign(new Error('Aborted'), {
+      name: 'AbortError'
+    })
+
+    global.fetch.mockRejectedValueOnce(abortError)
+
+    const controller = new AbortController()
+    await expect(
+      fetchTopItemsForMosaic(
+        searchParams,
+        5,
+        DEFAULT_MOSAIC_TOP_ITEMS_ERROR_SUMMARY,
+        controller.signal
+      )
+    ).rejects.toBe(abortError)
+    expect(consoleErrorSpy).not.toHaveBeenCalled()
+  })
+})

--- a/src/services/post-mosaic-service.js
+++ b/src/services/post-mosaic-service.js
@@ -1,32 +1,57 @@
 import { store } from '../redux/store'
 import { setSearchLoading, setMosaicCache } from '../redux/slices/mainSlice'
 import { addMosaicLayer } from '../utils/mapHelper'
+import {
+  normalizeStacErrorResponse,
+  normalizeStacNetworkError
+} from '../utils/stacErrorHelper'
 
-export async function AddMosaicService(reqParams, cacheMetadata) {
+const DEFAULT_MOSAIC_ERROR_SUMMARY = 'Error Fetching Mosaic'
+
+export async function AddMosaicService(
+  reqParams,
+  cacheMetadata,
+  contextLabel = DEFAULT_MOSAIC_ERROR_SUMMARY,
+  signal
+) {
   const mosaicTilerURL = store.getState().mainSlice.appConfig.MOSAIC_TILER_URL
-  await fetch(`${mosaicTilerURL}/mosaicjson/mosaics`, reqParams)
-    .then((response) => {
-      if (response.ok) {
-        return response.json()
-      }
-      throw new Error()
-    })
-    .then((json) => {
-      addMosaicLayer(json)
-      if (cacheMetadata) {
-        store.dispatch(
-          setMosaicCache({
-            lastMosaicRequestSignature: cacheMetadata.signature,
-            lastMosaicTopItemIds: cacheMetadata.topItemIds,
-            lastMosaicCompareCount: cacheMetadata.compareCount
-          })
-        )
-      }
-    })
-    .catch((error) => {
+  const fetchInit = signal ? { ...reqParams, signal } : reqParams
+  try {
+    const response = await fetch(
+      `${mosaicTilerURL}/mosaicjson/mosaics`,
+      fetchInit
+    )
+
+    if (!response.ok) {
+      const normalizedError = await normalizeStacErrorResponse(
+        response,
+        contextLabel
+      )
       store.dispatch(setSearchLoading(false))
-      const message = 'Error Fetching Mosaic'
-      // log full error for diagnosing client side errors if needed
-      console.error(message, error)
-    })
+      console.error(contextLabel, normalizedError)
+      return normalizedError
+    }
+
+    const json = await response.json()
+    addMosaicLayer(json)
+    if (cacheMetadata) {
+      store.dispatch(
+        setMosaicCache({
+          lastMosaicRequestSignature: cacheMetadata.signature,
+          lastMosaicTopItemIds: cacheMetadata.topItemIds,
+          lastMosaicCompareCount: cacheMetadata.compareCount
+        })
+      )
+    }
+    return undefined
+  } catch (error) {
+    if (error?.name === 'AbortError') {
+      store.dispatch(setSearchLoading(false))
+      return undefined
+    }
+    const normalizedError = normalizeStacNetworkError(error, contextLabel)
+    store.dispatch(setSearchLoading(false))
+    console.error(contextLabel, normalizedError)
+    return normalizedError
+  }
 }

--- a/src/services/post-mosaic-service.test.js
+++ b/src/services/post-mosaic-service.test.js
@@ -1,0 +1,80 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { AddMosaicService } from './post-mosaic-service'
+import { store } from '../redux/store'
+import { setappConfig } from '../redux/slices/mainSlice'
+
+const DEFAULT_MOSAIC_ERROR_SUMMARY = 'Error Fetching Mosaic'
+
+global.fetch = vi.fn()
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  store.dispatch(
+    setappConfig({
+      MOSAIC_TILER_URL: 'https://mosaic.example.com',
+      FETCH_CREDENTIALS: 'same-origin'
+    })
+  )
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('AddMosaicService error handling', () => {
+  it('returns normalized error with mosaic-specific summary for non-OK responses', async () => {
+    global.fetch.mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      text: async () => JSON.stringify({ code: 'BadRequest', message: 'bad' })
+    })
+
+    const result = await AddMosaicService({ method: 'POST' })
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        error: true,
+        status: 400,
+        summary: DEFAULT_MOSAIC_ERROR_SUMMARY,
+        details: 'bad'
+      })
+    )
+  })
+
+  it('returns normalized network error with mosaic-specific summary', async () => {
+    global.fetch.mockRejectedValueOnce(new Error('Network error'))
+
+    const result = await AddMosaicService({ method: 'POST' })
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        error: true,
+        status: null,
+        summary: DEFAULT_MOSAIC_ERROR_SUMMARY,
+        details: 'Network error'
+      })
+    )
+  })
+
+  it('returns undefined on fetch abort without normalizing', async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {})
+    const abortError = Object.assign(new Error('Aborted'), {
+      name: 'AbortError'
+    })
+
+    global.fetch.mockRejectedValueOnce(abortError)
+
+    const controller = new AbortController()
+    const result = await AddMosaicService(
+      { method: 'POST' },
+      null,
+      DEFAULT_MOSAIC_ERROR_SUMMARY,
+      controller.signal
+    )
+
+    expect(result).toBeUndefined()
+    expect(consoleErrorSpy).not.toHaveBeenCalled()
+  })
+})

--- a/src/utils/searchHelper.js
+++ b/src/utils/searchHelper.js
@@ -46,7 +46,10 @@ import { AddMosaicService } from '../services/post-mosaic-service'
 import { router, getPathParams } from '../router'
 import { appendStacHeaderCookies } from '../utils/stacRequest'
 import { serializeQueryableFiltersForUrl } from './urlParamHelper'
-import { STAC_UPLOAD_ERROR_CONTEXT_LABEL } from './stacErrorHelper'
+import {
+  STAC_UPLOAD_ERROR_CONTEXT_LABEL,
+  getStacErrorResult
+} from './stacErrorHelper'
 import { showApplicationAlert } from '../utils/alertHelper'
 
 /**
@@ -90,10 +93,6 @@ export function buildQueryFromFilters(queryableFilters) {
   })
 
   return query
-}
-
-function getStacErrorResult(result) {
-  return result && result.error ? result : undefined
 }
 
 function formatStacErrorMessage(result) {

--- a/src/utils/searchHelper.js
+++ b/src/utils/searchHelper.js
@@ -46,6 +46,8 @@ import { AddMosaicService } from '../services/post-mosaic-service'
 import { router, getPathParams } from '../router'
 import { appendStacHeaderCookies } from '../utils/stacRequest'
 import { serializeQueryableFiltersForUrl } from './urlParamHelper'
+import { STAC_UPLOAD_ERROR_CONTEXT_LABEL } from './stacErrorHelper'
+import { showApplicationAlert } from '../utils/alertHelper'
 
 /**
  * Convert queryable filters from Redux state into STAC Query Extension format
@@ -90,8 +92,20 @@ export function buildQueryFromFilters(queryableFilters) {
   return query
 }
 
+function getStacErrorResult(result) {
+  return result && result.error ? result : undefined
+}
+
+function formatStacErrorMessage(result) {
+  const detailsText =
+    result.details && result.code
+      ? `${result.code}: ${result.details}`
+      : result.details || ''
+  return detailsText ? `${result.summary}: ${detailsText}` : result.summary
+}
+
 export async function newSearch(options = {}) {
-  const { viewMode: overrideViewMode, preserveItem = false } = options
+  const { viewMode: overrideViewMode, preserveItem = false, signal } = options
 
   // Snapshot all needed Redux state upfront, before any dispatches or URL writes.
   const _state = store.getState().mainSlice
@@ -163,7 +177,7 @@ export async function newSearch(options = {}) {
       return
     }
     store.dispatch(setSearchLoading(true))
-    return newMosaicSearch()
+    return newMosaicSearch(signal)
   }
 
   // Get minimum zoom level for scene/mosaic views
@@ -194,21 +208,42 @@ export async function newSearch(options = {}) {
     const searchScenesParams = buildSearchScenesParams()
     store.dispatch(setSearchType('scene'))
     store.dispatch(setSearchLoading(true))
-    getSearchService.SearchService(searchScenesParams, 'scene')
+    const searchResult = await getSearchService.SearchService(
+      searchScenesParams,
+      'scene',
+      undefined,
+      signal
+    )
+    const normalizedError = getStacErrorResult(searchResult)
+    if (normalizedError) return normalizedError
     return
   } else if (viewMode === 'hex' && includesGeoHex) {
     // User wants hex view - no zoom restriction
     const searchAggregateParams = buildSearchAggregateParams('hex')
     store.dispatch(setSearchLoading(true))
     store.dispatch(setSearchType('hex'))
-    AggregateSearchService(searchAggregateParams, 'hex')
+    const result = await AggregateSearchService(
+      searchAggregateParams,
+      'hex',
+      undefined,
+      signal
+    )
+    const normalizedError = getStacErrorResult(result)
+    if (normalizedError) return normalizedError
     return
   } else if (viewMode === 'grid-code' && includesGridCode) {
     // User wants grid-code view - no zoom restriction
     const searchAggregateParams = buildSearchAggregateParams('grid-code')
     store.dispatch(setSearchType('grid-code'))
     store.dispatch(setSearchLoading(true))
-    AggregateSearchService(searchAggregateParams, 'grid-code')
+    const result = await AggregateSearchService(
+      searchAggregateParams,
+      'grid-code',
+      undefined,
+      signal
+    )
+    const normalizedError = getStacErrorResult(result)
+    if (normalizedError) return normalizedError
     return
   }
 
@@ -217,11 +252,32 @@ export async function newSearch(options = {}) {
     const searchScenesParams = buildSearchScenesParams()
     store.dispatch(setSearchType('scene'))
     store.dispatch(setSearchLoading(true))
-    getSearchService.SearchService(searchScenesParams, 'scene')
+    const searchResult = await getSearchService.SearchService(
+      searchScenesParams,
+      'scene',
+      undefined,
+      signal
+    )
+    const normalizedError = getStacErrorResult(searchResult)
+    if (normalizedError) return normalizedError
   } else {
     store.dispatch(setZoomLevelNeeded(sceneMinZoom))
     store.dispatch(setShowZoomNotice(true))
   }
+}
+
+export async function validateUploadedGeometry(uploadedFeature, signal) {
+  const searchScenesParams = buildSearchScenesParams(undefined, {
+    intersectsGeometry: uploadedFeature.geometry,
+    limit: 1
+  })
+  const searchResult = await getSearchService.SearchService(
+    searchScenesParams,
+    'scene',
+    STAC_UPLOAD_ERROR_CONTEXT_LABEL,
+    signal
+  )
+  return getStacErrorResult(searchResult)
 }
 
 export function clearSearch() {
@@ -290,13 +346,19 @@ function buildSearchScenesParams(gridCodeToSearchIn, options = {}) {
   const collections = _selectedCollection.id
   const _searchGeojsonBoundary =
     store.getState().mainSlice.searchGeojsonBoundary
+  const intersectsGeometry = options.intersectsGeometry
 
   const searchParams = new Map([
     ['datetime', _dateTimeRange],
     ['limit', limit],
     ['collections', collections]
   ])
-  if (_searchGeojsonBoundary) {
+  if (intersectsGeometry) {
+    searchParams.set(
+      'intersects',
+      encodeURIComponent(JSON.stringify(intersectsGeometry))
+    )
+  } else if (_searchGeojsonBoundary) {
     searchParams.set(
       'intersects',
       encodeURIComponent(JSON.stringify(_searchGeojsonBoundary.geometry))
@@ -551,9 +613,25 @@ export function mapGridCodeFromJson(json) {
   }
 }
 
-export function searchGridCodeScenes(gridCodeToSearchIn) {
-  const searchScenesParams = buildSearchScenesParams(gridCodeToSearchIn)
-  getSearchService.SearchService(searchScenesParams, 'grid-code')
+export async function searchGridCodeScenes(gridCodeToSearchIn) {
+  try {
+    const searchScenesParams = buildSearchScenesParams(gridCodeToSearchIn)
+    const result = await getSearchService.SearchService(
+      searchScenesParams,
+      'grid-code'
+    )
+
+    const normalizedError = getStacErrorResult(result)
+    if (normalizedError) {
+      showApplicationAlert(
+        'warning',
+        formatStacErrorMessage(normalizedError),
+        5000
+      )
+    }
+  } catch (error) {
+    showApplicationAlert('warning', 'ERROR: ' + error.message.toString(), 5000)
+  }
 }
 
 export const debounceNewSearch = debounce(() => newSearch(), 300)
@@ -629,7 +707,7 @@ const areTopItemsEqual = (prevIds, nextIds, compareCount) => {
   return true
 }
 
-async function newMosaicSearch() {
+async function newMosaicSearch(signal) {
   const createMosaicBody = buildMosaicCreateBody()
   const signature = getMosaicRequestSignature(createMosaicBody)
   const state = store.getState().mainSlice
@@ -656,12 +734,20 @@ async function newMosaicSearch() {
     })
     const result = await getSearchService.fetchTopItemsForMosaic(
       searchParams,
-      compareCount
+      compareCount,
+      undefined,
+      signal
     )
     topItemIds = result.itemIds
     effectiveCompareCount = result.effectiveLimit
   } catch (error) {
+    if (error?.name === 'AbortError') {
+      store.dispatch(setSearchLoading(false))
+      return
+    }
     console.error('Error fetching top items for mosaic comparison', error)
+    store.dispatch(setSearchLoading(false))
+    return error
   }
 
   const compareWindow = Math.min(effectiveCompareCount, compareCount)
@@ -702,11 +788,20 @@ async function newMosaicSearch() {
   store.dispatch(setSearchResults(null))
   store.dispatch(setShowZoomNotice(false))
 
-  AddMosaicService(requestOptions, {
-    signature,
-    topItemIds,
-    compareCount: compareWindow
-  })
+  const mosaicResult = await AddMosaicService(
+    requestOptions,
+    {
+      signature,
+      topItemIds,
+      compareCount: compareWindow
+    },
+    undefined,
+    signal
+  )
+
+  if (mosaicResult && mosaicResult.error) {
+    return mosaicResult
+  }
 }
 
 const constructMosaicAssetVal = (collection) => {

--- a/src/utils/searchHelper.test.js
+++ b/src/utils/searchHelper.test.js
@@ -13,6 +13,7 @@ import {
 } from '../components/defaults'
 import {
   newSearch,
+  validateUploadedGeometry,
   buildUrlParamFromBBOX,
   buildSearchScenesParams,
   buildSearchAggregateParams
@@ -20,9 +21,19 @@ import {
 import * as mapHelper from './mapHelper'
 import { AddMosaicService } from '../services/post-mosaic-service'
 import * as getSearchService from '../services/get-search-service'
+import { AggregateSearchService } from '../services/get-aggregate-service'
+import { STAC_UPLOAD_ERROR_CONTEXT_LABEL } from './stacErrorHelper'
+
+const DEFAULT_SEARCH_ERROR_SUMMARY = 'Error Fetching Search Results'
+const DEFAULT_AGGREGATE_ERROR_SUMMARY =
+  'Error Fetching Aggregate Search Results'
 
 vi.mock('../services/post-mosaic-service', () => ({
   AddMosaicService: vi.fn()
+}))
+
+vi.mock('../services/get-aggregate-service', () => ({
+  AggregateSearchService: vi.fn()
 }))
 
 vi.mock('./mapHelper', async () => {
@@ -74,6 +85,7 @@ describe('searchHelper newSearch', () => {
       })
     )
     AddMosaicService.mockReset()
+    AggregateSearchService.mockReset()
     vi.spyOn(getSearchService, 'fetchTopItemsForMosaic').mockReset()
     mapHelper.hasMosaicImageLayer.mockReset()
     mapHelper.hasMosaicImageLayer.mockReturnValue(true)
@@ -90,7 +102,7 @@ describe('searchHelper newSearch', () => {
     expect(AddMosaicService).toHaveBeenCalledTimes(1)
   })
 
-  it('reuses mosaic when top-n items match previous cache', async () => {
+  it('reuses mosaic when signature + compare count + layer all match (first gate)', async () => {
     const itemIds = ['a', 'b', 'c']
     vi.spyOn(getSearchService, 'fetchTopItemsForMosaic').mockResolvedValue({
       itemIds,
@@ -107,14 +119,47 @@ describe('searchHelper newSearch', () => {
       setMosaicCache({
         lastMosaicRequestSignature: firstCacheMetadata.signature,
         lastMosaicTopItemIds: itemIds,
-        // In the app, compareCount is the configured
-        // comparison window size, not the number of
-        // items returned in a given response.
         lastMosaicCompareCount: DEFAULT_MOSAIC_TOP_COMPARE_ITEMS
       })
     )
 
     AddMosaicService.mockClear()
+
+    await newSearch({ viewMode: 'mosaic' })
+
+    expect(AddMosaicService).toHaveBeenCalledTimes(0)
+  })
+
+  it('reuses mosaic when top items match cache even though first gate misses due to compare count (second gate)', async () => {
+    // Only 3 items returned — compareWindow=3, but compareCount (configured max) = 100.
+    // First gate: lastMosaicCompareCount(3) !== compareCount(100) → fails → fetches items.
+    // Second gate: lastMosaicCompareCount(3) === compareWindow(3), layer exists, items match → skips.
+    const itemIds = ['a', 'b', 'c']
+    vi.spyOn(getSearchService, 'fetchTopItemsForMosaic').mockResolvedValue({
+      itemIds,
+      effectiveLimit: itemIds.length
+    })
+
+    await newSearch({ viewMode: 'mosaic' })
+
+    expect(AddMosaicService).toHaveBeenCalledTimes(1)
+
+    const [, firstCacheMetadata] = AddMosaicService.mock.calls[0]
+    // compareCount stored by AddMosaicService is compareWindow (3), not the configured max (100)
+    expect(firstCacheMetadata.compareCount).toBe(itemIds.length)
+
+    store.dispatch(
+      setMosaicCache({
+        lastMosaicRequestSignature: firstCacheMetadata.signature,
+        lastMosaicTopItemIds: itemIds,
+        lastMosaicCompareCount: firstCacheMetadata.compareCount
+      })
+    )
+
+    AddMosaicService.mockClear()
+    // Layer still present; first gate will miss (compareCount 100 ≠ cached 3),
+    // second gate must carry the load.
+    mapHelper.hasMosaicImageLayer.mockReturnValue(true)
 
     await newSearch({ viewMode: 'mosaic' })
 
@@ -191,14 +236,94 @@ describe('searchHelper newSearch', () => {
     expect(cacheMetadata.compareCount).toBe(DEFAULT_MOSAIC_TOP_COMPARE_ITEMS)
   })
 
-  it('still creates mosaic when fetchTopItemsForMosaic rejects (fallback)', async () => {
+  it('returns inline error when fetchTopItemsForMosaic rejects', async () => {
+    const normalizedError = {
+      error: true,
+      status: null,
+      code: null,
+      summary: DEFAULT_SEARCH_ERROR_SUMMARY,
+      details: 'Network error'
+    }
+
     vi.spyOn(getSearchService, 'fetchTopItemsForMosaic').mockRejectedValue(
-      new Error('Network error')
+      normalizedError
+    )
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {})
+
+    const result = await newSearch({ viewMode: 'mosaic' })
+
+    expect(AddMosaicService).toHaveBeenCalledTimes(0)
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'Error fetching top items for mosaic comparison',
+      normalizedError
+    )
+    expect(result).toBe(normalizedError)
+  })
+
+  it('returns undefined when fetchTopItemsForMosaic aborts', async () => {
+    const abortError = Object.assign(new Error('Aborted'), {
+      name: 'AbortError'
+    })
+    vi.spyOn(getSearchService, 'fetchTopItemsForMosaic').mockRejectedValue(
+      abortError
     )
 
-    await newSearch({ viewMode: 'mosaic' })
+    const result = await newSearch({ viewMode: 'mosaic' })
 
-    expect(AddMosaicService).toHaveBeenCalledTimes(1)
+    expect(AddMosaicService).toHaveBeenCalledTimes(0)
+    expect(result).toBeUndefined()
+  })
+
+  it('propagates inline error for hex view from AggregateSearchService', async () => {
+    store.dispatch(
+      setSelectedCollectionData({
+        ...mockCollection,
+        aggregations: [{ name: 'centroid_geohex_grid_frequency' }]
+      })
+    )
+
+    const normalizedError = {
+      error: true,
+      status: 400,
+      code: 'BadRequest',
+      summary: DEFAULT_AGGREGATE_ERROR_SUMMARY,
+      details: 'geo coordinates must be numbers'
+    }
+
+    AggregateSearchService.mockResolvedValueOnce(normalizedError)
+
+    const result = await newSearch({ viewMode: 'hex' })
+
+    expect(AggregateSearchService).toHaveBeenCalledTimes(1)
+    expect(AddMosaicService).toHaveBeenCalledTimes(0)
+    expect(result).toBe(normalizedError)
+  })
+
+  it('propagates inline error for grid-code view from AggregateSearchService', async () => {
+    store.dispatch(
+      setSelectedCollectionData({
+        ...mockCollection,
+        aggregations: [{ name: 'grid_code_frequency' }]
+      })
+    )
+
+    const normalizedError = {
+      error: true,
+      status: 400,
+      code: 'BadRequest',
+      summary: DEFAULT_AGGREGATE_ERROR_SUMMARY,
+      details: 'geo coordinates must be numbers'
+    }
+
+    AggregateSearchService.mockResolvedValueOnce(normalizedError)
+
+    const result = await newSearch({ viewMode: 'grid-code' })
+
+    expect(AggregateSearchService).toHaveBeenCalledTimes(1)
+    expect(AddMosaicService).toHaveBeenCalledTimes(0)
+    expect(result).toBe(normalizedError)
   })
 })
 
@@ -299,5 +424,73 @@ describe('searchHelper bbox precision', () => {
       const result = buildSearchAggregateParams('hex')
       expect(result).not.toContain('bbox=')
     })
+  })
+})
+
+describe('validateUploadedGeometry', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    store.dispatch(
+      setappConfig({
+        STAC_API_URL: 'https://example.com/stac',
+        FETCH_CREDENTIALS: 'same-origin',
+        APP_TOKEN_AUTH_ENABLED: false
+      })
+    )
+    store.dispatch(
+      setSelectedCollectionData({
+        ...mockCollection
+      })
+    )
+  })
+
+  it('calls SearchService with upload-specific error context', async () => {
+    const uploadedFeature = {
+      type: 'Feature',
+      geometry: { type: 'Point', coordinates: [0, 0] },
+      properties: {}
+    }
+    const searchServiceSpy = vi
+      .spyOn(getSearchService, 'SearchService')
+      .mockResolvedValueOnce(undefined)
+
+    const result = await validateUploadedGeometry(uploadedFeature)
+
+    expect(result).toBeUndefined()
+    expect(searchServiceSpy).toHaveBeenCalledWith(
+      expect.stringContaining('intersects='),
+      'scene',
+      STAC_UPLOAD_ERROR_CONTEXT_LABEL,
+      undefined
+    )
+  })
+
+  it('returns normalized error independent of current view mode and zoom', async () => {
+    store.dispatch(
+      setSelectedCollectionData({
+        ...mockCollection,
+        aggregations: [{ name: 'grid_code_frequency' }]
+      })
+    )
+    const uploadedFeature = {
+      type: 'Feature',
+      geometry: { type: 'Point', coordinates: [0, 0] },
+      properties: {}
+    }
+    const normalizedError = {
+      error: true,
+      status: 400,
+      code: 'BadRequest',
+      summary: STAC_UPLOAD_ERROR_CONTEXT_LABEL,
+      details: 'geo coordinates must be numbers'
+    }
+
+    vi.spyOn(getSearchService, 'SearchService').mockResolvedValueOnce(
+      normalizedError
+    )
+
+    const result = await validateUploadedGeometry(uploadedFeature)
+
+    expect(result).toEqual(normalizedError)
   })
 })

--- a/src/utils/stacErrorHelper.js
+++ b/src/utils/stacErrorHelper.js
@@ -1,0 +1,98 @@
+export const STAC_UPLOAD_ERROR_CONTEXT_LABEL =
+  'Unable to search the uploaded area'
+
+export const MAX_STAC_ERROR_BODY_CHARS = 32768
+
+function unquoteIfJsonString(s) {
+  const trimmed = s.trim()
+  if (trimmed.startsWith('"') && trimmed.endsWith('"') && trimmed.length >= 2) {
+    try {
+      const unquoted = JSON.parse(trimmed)
+      return typeof unquoted === 'string' ? unquoted : s
+    } catch (e) {
+      return s
+    }
+  }
+  return s
+}
+
+export async function normalizeStacErrorResponse(response, contextLabel) {
+  const status = response?.status ?? null
+  const baseLabel = contextLabel || 'STAC request failed'
+
+  let rawText = ''
+  try {
+    const fullText = await response.text()
+    rawText =
+      fullText.length > MAX_STAC_ERROR_BODY_CHARS
+        ? `${fullText.slice(0, MAX_STAC_ERROR_BODY_CHARS)}\n…[truncated]`
+        : fullText
+  } catch (error) {
+    // If we cannot read the body, fall back to status-only messaging
+    return {
+      error: true,
+      status,
+      code: null,
+      summary: `${baseLabel} (status ${status ?? 'unknown'})`,
+      details: ''
+    }
+  }
+
+  if (!rawText) {
+    return {
+      error: true,
+      status,
+      code: null,
+      summary: baseLabel,
+      details: `Request failed${status ? ` (status ${status})` : ''}`
+    }
+  }
+
+  try {
+    const json = JSON.parse(rawText)
+    const code = json.code || null
+    const summary = baseLabel
+
+    const rawDetails =
+      json.message || json.detail || json.title || json.description || rawText
+
+    // Some backends wrap the human message in a JSON-string, e.g.
+    // description: "\"geo coordinates must be numbers\""
+    // After JSON parsing, that becomes a string that still includes quotes.
+    const details =
+      typeof rawDetails === 'string'
+        ? unquoteIfJsonString(rawDetails)
+        : typeof rawDetails === 'undefined'
+          ? ''
+          : JSON.stringify(rawDetails)
+
+    return {
+      error: true,
+      status,
+      code,
+      summary,
+      details
+    }
+  } catch (error) {
+    // Non-JSON body, treat as plain text
+    return {
+      error: true,
+      status,
+      code: null,
+      summary: baseLabel,
+      details: rawText
+    }
+  }
+}
+
+export function normalizeStacNetworkError(error, contextLabel) {
+  const baseLabel = contextLabel || 'STAC request failed'
+
+  return {
+    error: true,
+    status: null,
+    code: null,
+    summary: baseLabel,
+    details: error?.message || String(error)
+  }
+}

--- a/src/utils/stacErrorHelper.js
+++ b/src/utils/stacErrorHelper.js
@@ -3,6 +3,10 @@ export const STAC_UPLOAD_ERROR_CONTEXT_LABEL =
 
 export const MAX_STAC_ERROR_BODY_CHARS = 32768
 
+export function getStacErrorResult(result) {
+  return result && result.error ? result : undefined
+}
+
 function unquoteIfJsonString(s) {
   const trimmed = s.trim()
   if (trimmed.startsWith('"') && trimmed.endsWith('"') && trimmed.length >= 2) {

--- a/src/utils/stacErrorHelper.test.js
+++ b/src/utils/stacErrorHelper.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 import {
   STAC_UPLOAD_ERROR_CONTEXT_LABEL,
   MAX_STAC_ERROR_BODY_CHARS,
+  getStacErrorResult,
   normalizeStacErrorResponse,
   normalizeStacNetworkError
 } from './stacErrorHelper'
@@ -162,5 +163,18 @@ describe('normalizeStacNetworkError', () => {
         details: 'Network error'
       })
     )
+  })
+})
+
+describe('getStacErrorResult', () => {
+  it('returns result when error flag is present', () => {
+    const result = { error: true, summary: 'Boom' }
+    expect(getStacErrorResult(result)).toBe(result)
+  })
+
+  it('returns undefined when result is missing or not an error payload', () => {
+    expect(getStacErrorResult(undefined)).toBeUndefined()
+    expect(getStacErrorResult({})).toBeUndefined()
+    expect(getStacErrorResult({ error: false })).toBeUndefined()
   })
 })

--- a/src/utils/stacErrorHelper.test.js
+++ b/src/utils/stacErrorHelper.test.js
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+  STAC_UPLOAD_ERROR_CONTEXT_LABEL,
+  MAX_STAC_ERROR_BODY_CHARS,
+  normalizeStacErrorResponse,
+  normalizeStacNetworkError
+} from './stacErrorHelper'
+
+describe('normalizeStacErrorResponse', () => {
+  it('returns status-only messaging for empty response body', async () => {
+    const response = {
+      status: 400,
+      text: vi.fn(async () => '')
+    }
+
+    const result = await normalizeStacErrorResponse(
+      response,
+      STAC_UPLOAD_ERROR_CONTEXT_LABEL
+    )
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        error: true,
+        status: 400,
+        code: null,
+        summary: STAC_UPLOAD_ERROR_CONTEXT_LABEL,
+        details: 'Request failed (status 400)'
+      })
+    )
+  })
+
+  it('treats non-JSON bodies as plain text', async () => {
+    const response = {
+      status: 400,
+      text: vi.fn(async () => 'Bad Request')
+    }
+
+    const result = await normalizeStacErrorResponse(
+      response,
+      STAC_UPLOAD_ERROR_CONTEXT_LABEL
+    )
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        error: true,
+        status: 400,
+        code: null,
+        summary: STAC_UPLOAD_ERROR_CONTEXT_LABEL,
+        details: 'Bad Request'
+      })
+    )
+  })
+
+  it('unwraps quoted JSON-string messages', async () => {
+    const responseBody = {
+      code: 'BadRequest',
+      description: '"geo coordinates must be numbers"'
+    }
+
+    const response = {
+      status: 400,
+      text: vi.fn(async () => JSON.stringify(responseBody))
+    }
+
+    const result = await normalizeStacErrorResponse(
+      response,
+      STAC_UPLOAD_ERROR_CONTEXT_LABEL
+    )
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        error: true,
+        status: 400,
+        code: 'BadRequest',
+        summary: STAC_UPLOAD_ERROR_CONTEXT_LABEL,
+        details: 'geo coordinates must be numbers'
+      })
+    )
+  })
+
+  it('stringifies non-string message objects', async () => {
+    const responseBody = {
+      code: 'BadRequest',
+      message: { foo: 'bar' }
+    }
+
+    const response = {
+      status: 400,
+      text: vi.fn(async () => JSON.stringify(responseBody))
+    }
+
+    const result = await normalizeStacErrorResponse(
+      response,
+      STAC_UPLOAD_ERROR_CONTEXT_LABEL
+    )
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        error: true,
+        status: 400,
+        code: 'BadRequest',
+        summary: STAC_UPLOAD_ERROR_CONTEXT_LABEL,
+        details: JSON.stringify(responseBody.message)
+      })
+    )
+  })
+
+  it('handles very long message strings', async () => {
+    const longMessage = 'a'.repeat(20000)
+    const responseBody = {
+      code: 'BadRequest',
+      message: longMessage
+    }
+
+    const response = {
+      status: 400,
+      text: vi.fn(async () => JSON.stringify(responseBody))
+    }
+
+    const result = await normalizeStacErrorResponse(
+      response,
+      STAC_UPLOAD_ERROR_CONTEXT_LABEL
+    )
+
+    expect(result.details).toBe(longMessage)
+  })
+
+  it('truncates oversized non-JSON error bodies', async () => {
+    const huge = 'h'.repeat(MAX_STAC_ERROR_BODY_CHARS + 5000)
+    const response = {
+      status: 502,
+      text: vi.fn(async () => huge)
+    }
+
+    const result = await normalizeStacErrorResponse(
+      response,
+      STAC_UPLOAD_ERROR_CONTEXT_LABEL
+    )
+
+    const suffix = '\n…[truncated]'
+    expect(result.details.length).toBe(
+      MAX_STAC_ERROR_BODY_CHARS + suffix.length
+    )
+    expect(result.details.endsWith(suffix)).toBe(true)
+    expect(result.details.startsWith('h')).toBe(true)
+  })
+})
+
+describe('normalizeStacNetworkError', () => {
+  it('normalizes network errors into a STAC-like shape', () => {
+    const result = normalizeStacNetworkError(
+      new Error('Network error'),
+      STAC_UPLOAD_ERROR_CONTEXT_LABEL
+    )
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        error: true,
+        status: null,
+        code: null,
+        summary: STAC_UPLOAD_ERROR_CONTEXT_LABEL,
+        details: 'Network error'
+      })
+    )
+  })
+})

--- a/src/utils/stacRequest.js
+++ b/src/utils/stacRequest.js
@@ -1,6 +1,18 @@
 import Cookies from 'js-cookie'
 import { store } from '../redux/store'
 
+export function buildStacRequestHeaders() {
+  const requestHeaders = new Headers()
+  const JWT = localStorage.getItem('APP_AUTH_TOKEN')
+  const isSTACTokenAuthEnabled =
+    store.getState().mainSlice.appConfig.APP_TOKEN_AUTH_ENABLED ?? false
+  if (JWT && isSTACTokenAuthEnabled) {
+    requestHeaders.append('Authorization', `Bearer ${JWT}`)
+  }
+  appendStacHeaderCookies(requestHeaders)
+  return requestHeaders
+}
+
 // STAC_HEADER_COOKIES config can define cookies whose values we want to
 // include in STAC API request headers. if any exist, append them to the
 // request headers


### PR DESCRIPTION
## Summary

Hardens the GeoJSON upload flow and STAC clients: normalized errors, optional request cancellation via `AbortSignal`, clearer modal UX, and tests across services and helpers.

## Changes

- **Upload modal** — Preflight validation with `validateUploadedGeometry`, inline MUI error UI (scrollable details), flex layout / max-height, double-submit guard; **Cancel** aborts in-flight requests and clears AOI/draw layer; failed post-upload search rolls back AOI and shows errors.
- **`stacErrorHelper`** — New helpers to normalize HTTP and network failures; cap oversized error bodies (`MAX_STAC_ERROR_BODY_CHARS`).
- **`stacRequest`** — `buildStacRequestHeaders` for shared auth/cookie headers.
- **STAC services** — `SearchService`, `fetchTopItemsForMosaic`, `AggregateSearchService`, `AddMosaicService` return structured errors, support optional `signal`, consistent `contextLabel` logging; mosaic errors log with `contextLabel`.
- **`searchHelper`** — `newSearch({ signal })` threading; upload validation + error propagation; mosaic path respects abort on prefetch/mosaic fetch.
- **Tests** — Modal, `stacErrorHelper`, search/aggregate/mosaic services, and `searchHelper` (including abort and AOI rollback).

**PR Checklist:**

- [x] I have added my changes to the [CHANGELOG](https://github.com/Element84/filmdrop-ui/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
