### PR TITLE
Recognize centroid_geohex_grid_frequency in ViewSelector hex gating

### DIFF
--- a/src/components/ViewSelector/ViewSelector.jsx
+++ b/src/components/ViewSelector/ViewSelector.jsx
@@ -38,10 +38,13 @@ const ViewSelector = () => {
   )
 
   // Check if collection supports hex and grid aggregations
+  // Check for both new (stac-server >= 3.6.0) and old (deprecated) aggregation names
   const supportsHex = useMemo(
     () =>
       selectedCollectionData?.aggregations?.some(
-        (el) => el.name === 'grid_geohex_frequency'
+        (el) =>
+          el.name === 'centroid_geohex_grid_frequency' ||
+          el.name === 'grid_geohex_frequency'
       ) || false,
     [selectedCollectionData]
   )

--- a/src/components/ViewSelector/ViewSelector.test.jsx
+++ b/src/components/ViewSelector/ViewSelector.test.jsx
@@ -106,8 +106,16 @@ describe('ViewSelector', () => {
         expect(getButton('Hex')).toBeDisabled()
       })
 
-      it('should be enabled when collection supports hex aggregation', () => {
+      it('should be enabled when collection supports hex aggregation (legacy name)', () => {
         setup({}, { aggregations: [{ name: 'grid_geohex_frequency' }] })
+        expect(getButton('Hex')).not.toBeDisabled()
+      })
+
+      it('should be enabled when collection supports hex aggregation (centroid name)', () => {
+        setup(
+          {},
+          { aggregations: [{ name: 'centroid_geohex_grid_frequency' }] }
+        )
         expect(getButton('Hex')).not.toBeDisabled()
       })
     })


### PR DESCRIPTION
## Summary

Fixes #571.

`ViewSelector.jsx` only matched the legacy aggregation name `grid_geohex_frequency` when deciding whether to enable the Hex view button. stac-server 3.6.0 deprecated that name in favor of `centroid_geohex_grid_frequency`, so collections served by a current stac-server (which advertises only the new name) had the Hex button disabled with the tooltip "Hex aggregation not available for this collection," even when the aggregation worked correctly.

`src/utils/searchHelper.js` already handled both names (with the comment "Check for both new (stac-server >= 3.6.0) and old (deprecated) aggregation names"). `ViewSelector.jsx` was missed. This change mirrors that precedent.

## Changes

- `src/components/ViewSelector/ViewSelector.jsx` — `supportsHex` now matches either `centroid_geohex_grid_frequency` or `grid_geohex_frequency`.
- `src/components/ViewSelector/ViewSelector.test.jsx` — adds a test case for the new (centroid) aggregation name; existing legacy-name test retained.

## Test plan

- [x] `npm run test-pre-commit` — all 642 tests pass under node 22.18 (per `.nvmrc`)
- [x] `npm run format` passes
- [x] `npm run check-markdown` passes
- [x] New unit test verifies Hex button is enabled when only `centroid_geohex_grid_frequency` is advertised
- [x] Existing unit test continues to verify Hex button is enabled with the legacy `grid_geohex_frequency` name
- [ ] Manual verification against a live stac-server >= 3.6.0 collection (downstream)