### PR TITLE
Extract bidx from STAC render extension in autoConfigureRendering

### DIFF
--- a/src/utils/configHelper.js
+++ b/src/utils/configHelper.js
@@ -454,6 +454,14 @@ export function autoConfigureRendering(config) {
         processedRender.expression = renderDef.expression
       }
 
+      // Optional: bidx
+      // Stored as a comma-separated string so it survives both URL builders
+      // in mapHelper.js: the scene-tiler path produces `asset_bidx=<asset>|<value>`
+      // and the mosaic path splits on `,` to emit `bidx=<n>` per band.
+      if (renderDef.bidx && Array.isArray(renderDef.bidx)) {
+        processedRender.bidx = renderDef.bidx.join(',')
+      }
+
       // Optional: resampling (map to TiTiler's resampling_method)
       if (renderDef.resampling) {
         processedRender.resampling = renderDef.resampling

--- a/src/utils/configHelper.test.js
+++ b/src/utils/configHelper.test.js
@@ -310,6 +310,39 @@ describe('ConfigHelper', () => {
       expect(params.color_formula).toEqual('Gamma+RGB+3.2')
     })
 
+    it('should extract bidx as a comma-separated string', () => {
+      const config = {
+        SCENE_TILER_URL: 'https://example.com/titiler',
+        COLLECTIONS_CONFIG: {
+          dove: {}
+        },
+        _STAC_COLLECTIONS: [
+          {
+            id: 'dove',
+            renders: {
+              'true-color': {
+                title: 'True Color',
+                assets: ['analytic_cog'],
+                bidx: [6, 4, 2],
+                rescale: [
+                  [0, 3000],
+                  [0, 3000],
+                  [0, 3000]
+                ],
+                color_formula: 'Gamma RGB 3.5'
+              }
+            }
+          }
+        ]
+      }
+
+      const result = autoConfigureRendering(config)
+      const params = result.COLLECTIONS_CONFIG.dove.visualizations['true-color']
+
+      expect(params.assets).toEqual(['analytic_cog'])
+      expect(params.bidx).toEqual('6,4,2')
+    })
+
     it('should handle colormap_name and expression', () => {
       const config = {
         SCENE_TILER_URL: 'https://example.com/titiler',


### PR DESCRIPTION
## Summary

Fixes #574.

`autoConfigureRendering` in `src/utils/configHelper.js` extracts 9 of the 10 standard fields from the [STAC render extension v2.0.0 schema](https://github.com/stac-extensions/render/blob/v2.0.0/json-schema/schema.json) but silently drops `bidx` (`array of numbers` per spec). The URL builder in `src/utils/mapHelper.js` lines 728–740 already implements both forms (`asset_bidx=<asset>|...` for the scene-tiler path and `bidx=<n>` per band for the mosaic path) — it just never receives a value because the extraction step doesn't put one on `processedRender`.

For collections that use `bidx` to select bands from a multi-band asset, the resulting tile URL has no band selection at all, and TiTiler 500s on the PNG encoder when it tries to write all the asset's bands into a 3-channel PNG.

## Changes

- `src/utils/configHelper.js` — extract `bidx` (when it's an array) and store it as a comma-separated string on `processedRender`. The string form satisfies both downstream URL builders without changes.
- `src/utils/configHelper.test.js` — adds a focused test using a Planet Dove–style render config.

## Caveat

Note: the commit message references #573 instead of #574 (issue number was guessed before filing). The PR body is authoritative.

## Test plan

- [x] `npm run test-pre-commit` — 642/642 tests pass under node 22.18 (per `.nvmrc`)
- [x] `npm run format` passes
- [x] New test case verifies `bidx: [6, 4, 2]` becomes `bidx: '6,4,2'` on `processedRender`
- [ ] Manual: deploy against a collection with `bidx` in renders and confirm the resulting tile URL has `asset_bidx=<asset>|6,4,2` and renders correctly